### PR TITLE
Replugged update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 prepros.config
 .vscode
 .prettierignore
-node_modules
+/node_modules
 .parcel-cache
-dist
+/dist
+/bundle
 /.idea/

--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2021-2024 Nyria
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app.scss
+++ b/app.scss
@@ -16,5 +16,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Material+Icons");
 
 .member_aa4760 .username__11d8c::after {
-    left: 15px !important;
+  left: 15px !important;
 }

--- a/app.scss
+++ b/app.scss
@@ -15,6 +15,6 @@
 // Font Importing
 @import url("https://fonts.googleapis.com/css2?family=Material+Icons");
 
-.member_aa4760 .username__11d8c::after {
+.member_aa4760 .username_ab1e31::after {
   left: 15px !important;
 }

--- a/betterdiscord/app.css
+++ b/betterdiscord/app.css
@@ -6,7 +6,10 @@
 :root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503 {
   padding-left: 50px;
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503.groupStart__7b93c .contents_d3ae0d::after {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503.groupStart__7b93c
+  .contents_d3ae0d::after {
   left: 48px;
   width: 30px;
   height: 30px;
@@ -18,7 +21,10 @@
   height: 30px;
   border-radius: var(--avatar-radius);
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503 .avatarDecoration__8a0c2 {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503
+  .avatarDecoration__8a0c2 {
   left: 43px;
   width: 40px;
   height: 40px;
@@ -29,46 +35,80 @@
   margin-bottom: 10px;
   width: 100%;
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503 .timestamp_c79dd2.alt__6c563 {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503
+  .timestamp_c79dd2.alt__6c563 {
   position: absolute;
   font-size: 0.6875rem !important;
   right: 10px;
   left: unset;
   opacity: 0;
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503:hover .timestamp_c79dd2 {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503:hover
+  .timestamp_c79dd2 {
   opacity: 1;
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503 .iconContainer_d0200f {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503
+  .iconContainer_d0200f {
   position: unset;
   width: unset;
   margin-right: 10px;
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503 .repliedMessage__636d2 {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503
+  .repliedMessage__636d2 {
   margin-left: 48px;
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503 .repliedMessage__636d2 .replyAvatar__4ba85 {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503
+  .repliedMessage__636d2
+  .replyAvatar__4ba85 {
   border-radius: calc(var(--avatar-radius) - 3px);
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503 .blockquoteContainer__66aaa .blockquoteDivider__5cbad {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503
+  .blockquoteContainer__66aaa
+  .blockquoteDivider__5cbad {
   display: none;
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503 .blockquoteContainer__66aaa blockquote {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503
+  .blockquoteContainer__66aaa
+  blockquote {
   padding: 12px;
   background: var(--background-secondary);
   border-radius: 4px;
   width: 100%;
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503.hasThread__44ae4::after {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503.hasThread__44ae4::after {
   margin-left: 24px;
   border-bottom: none;
   border-radius: 0;
   bottom: 70px;
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503.hasThread__44ae4 > .contents_d3ae0d > [id^=message-content-] {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503.hasThread__44ae4
+  > .contents_d3ae0d
+  > [id^="message-content-"] {
   padding-left: calc(var(--custom-message-margin-left-content-cozy) + 40px);
 }
-:root .messagesWrapper_add28b .cozy_f5c119.wrapper_a62503.hasThread__44ae4 .container__62863 > *:not(.container__17159) {
+:root
+  .messagesWrapper_add28b
+  .cozy_f5c119.wrapper_a62503.hasThread__44ae4
+  .container__62863
+  > *:not(.container__17159) {
   margin-left: 48px;
   border-radius: 8px;
 }
@@ -139,7 +179,8 @@
   margin-top: 5px !important;
   margin-bottom: 5px !important;
 }
-:root .divider__855e3 .content__7191e, :root .divider__855e3#---new-messages-bar .unreadPill__1b4fa {
+:root .divider__855e3 .content__7191e,
+:root .divider__855e3#---new-messages-bar .unreadPill__1b4fa {
   background: var(--background-secondary);
   width: 100%;
   padding: 10px;
@@ -216,7 +257,9 @@
 :root #emoji-picker-tab-panel .premiumPromo__9e1ca {
   background: var(--background-secondary);
   opacity: 1;
-  animation: fade 0.3s ease, zoom 0.3s ease;
+  animation:
+    fade 0.3s ease,
+    zoom 0.3s ease;
 }
 :root #emoji-picker-tab-panel.wrapper__0757b {
   margin-bottom: 8px;
@@ -244,7 +287,9 @@
   background: var(--background-primary);
   border: none;
 }
-:root #emoji-picker-tab-panel:not(.emojiPickerInExpressionPicker-2nOwH8) .inspector__80c84 {
+:root
+  #emoji-picker-tab-panel:not(.emojiPickerInExpressionPicker-2nOwH8)
+  .inspector__80c84 {
   position: absolute;
   top: unset;
   bottom: 0;
@@ -257,7 +302,10 @@
 :root #emoji-picker-tab-panel .wrapper__85934 {
   background: var(--background-secondary);
 }
-:root #emoji-picker-tab-panel .wrapper__85934 .scroller_ac6d1c::-webkit-scrollbar {
+:root
+  #emoji-picker-tab-panel
+  .wrapper__85934
+  .scroller_ac6d1c::-webkit-scrollbar {
   display: none;
 }
 :root #emoji-picker-tab-panel .badgeLabel__9518c {
@@ -288,7 +336,10 @@
 :root #sticker-picker-tab-panel .wrapper__85934 {
   background: var(--background-secondary);
 }
-:root #sticker-picker-tab-panel .wrapper__85934 .scroller_ac6d1c::-webkit-scrollbar {
+:root
+  #sticker-picker-tab-panel
+  .wrapper__85934
+  .scroller_ac6d1c::-webkit-scrollbar {
   display: none;
 }
 :root .uploadModal__6eb75 {
@@ -314,7 +365,12 @@
 :root .uploadModal__6eb75 .inner__7afe9 .file__068e1 .description__338ad {
   margin-top: 15px;
 }
-:root .uploadModal__6eb75 .inner__7afe9 .file__068e1 .description__338ad .filename_da9eea {
+:root
+  .uploadModal__6eb75
+  .inner__7afe9
+  .file__068e1
+  .description__338ad
+  .filename_da9eea {
   font-weight: 550;
 }
 :root .uploadModal__6eb75 .inner__7afe9 .file__068e1 .icon__4bc4d {
@@ -324,7 +380,11 @@
 :root .uploadModal__6eb75 .inner__7afe9 .file__068e1 .icon__4bc4d.video_edf1b6 {
   background-image: url(https://cdn.discordapp.com/attachments/539180316447997974/705623014334791720/videocam-white-18dp.svg);
 }
-:root .uploadModal__6eb75 .inner__7afe9 .file__068e1 .icon__4bc4d.acrobat__81c91 {
+:root
+  .uploadModal__6eb75
+  .inner__7afe9
+  .file__068e1
+  .icon__4bc4d.acrobat__81c91 {
   background-image: url(https://cdn.discordapp.com/attachments/539180316447997974/705623972791975936/picture_as_pdf-white-18dp.svg);
 }
 :root .uploadModal__6eb75 .footer_f06dbb {
@@ -339,12 +399,19 @@
   visibility: hidden;
   transition: 0.2s;
 }
-:root .uploadModal__6eb75 .checkboxWrapper_a2bcc8 .checkbox_fcf2ad.checked__16f88::before {
+:root
+  .uploadModal__6eb75
+  .checkboxWrapper_a2bcc8
+  .checkbox_fcf2ad.checked__16f88::before {
   color: var(--textcolor);
   content: "visibility_off";
 }
 :root .uploadModal__6eb75 .checkboxWrapper_a2bcc8 .checkbox_fcf2ad:hover,
-:root .uploadModal__6eb75 .checkboxWrapper_a2bcc8 .checkbox_fcf2ad .checked__16f88 {
+:root
+  .uploadModal__6eb75
+  .checkboxWrapper_a2bcc8
+  .checkbox_fcf2ad
+  .checked__16f88 {
   opacity: 1;
 }
 :root .uploadModal__6eb75 .checkboxWrapper_a2bcc8 .checkbox_fcf2ad::before {
@@ -417,10 +484,26 @@
 :root .wrapperAudio__178e9 .audioControls_da7066 .mediaBarWrapper_e90a7a:hover {
   box-shadow: none;
 }
-:root .wrapperAudio__178e9 .audioControls_da7066 .mediaBarWrapper_e90a7a .mediaBarProgress_a3b7f1,
-:root .wrapperAudio__178e9 .audioControls_da7066 .mediaBarWrapper_e90a7a .mediaBarProgress_a3b7f1:after,
-:root .wrapperAudio__178e9 .audioControls_da7066 .mediaBarWrapper_e90a7a .mediaBarProgress_a3b7f1:before,
-:root .wrapperAudio__178e9 .audioControls_da7066 .mediaBarWrapper_e90a7a .mediaBarGrabber__1d527 {
+:root
+  .wrapperAudio__178e9
+  .audioControls_da7066
+  .mediaBarWrapper_e90a7a
+  .mediaBarProgress_a3b7f1,
+:root
+  .wrapperAudio__178e9
+  .audioControls_da7066
+  .mediaBarWrapper_e90a7a
+  .mediaBarProgress_a3b7f1:after,
+:root
+  .wrapperAudio__178e9
+  .audioControls_da7066
+  .mediaBarWrapper_e90a7a
+  .mediaBarProgress_a3b7f1:before,
+:root
+  .wrapperAudio__178e9
+  .audioControls_da7066
+  .mediaBarWrapper_e90a7a
+  .mediaBarGrabber__1d527 {
   background: var(--main-color) !important;
 }
 :root .embedFull__14919 {
@@ -535,8 +618,14 @@
   z-index: -1;
   opacity: 0.3;
   filter: blur(20px);
-  mask-image: linear-gradient(rgba(0, 0, 0, 0.7333333333), rgba(0, 0, 0, 0.7333333333));
-  -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.7333333333), rgba(0, 0, 0, 0.7333333333));
+  mask-image: linear-gradient(
+    rgba(0, 0, 0, 0.7333333333),
+    rgba(0, 0, 0, 0.7333333333)
+  );
+  -webkit-mask-image: linear-gradient(
+    rgba(0, 0, 0, 0.7333333333),
+    rgba(0, 0, 0, 0.7333333333)
+  );
 }
 :root .popoutTopLeft-3B0mFf.noArrow-2foL9g.noShadow-3pu20z {
   margin-bottom: 0;
@@ -619,7 +708,12 @@
 :root .guilds__2b93a .scroller_de945b {
   padding: 30px 0;
 }
-:root .guilds__2b93a .scroller_de945b > .tutorialContainer__6835f:first-child > .listItem__48528 .childWrapper_a6ce15 {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  > .tutorialContainer__6835f:first-child
+  > .listItem__48528
+  .childWrapper_a6ce15 {
   background: var(--main-color);
   color: #fff;
 }
@@ -649,18 +743,44 @@
   bottom: 4px;
   right: -5px;
 }
-:root .guilds__2b93a .scroller_de945b .listItem__48528 .lowerBadge_e89e22 .numberBadge__40d6f {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .listItem__48528
+  .lowerBadge_e89e22
+  .numberBadge__40d6f {
   min-width: 25px;
   background: var(--main-color) !important;
   font-size: 8px;
 }
-:root .guilds__2b93a .scroller_de945b .listItem__48528 .lowerBadge_e89e22:last-child .numberBadge__40d6f {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .listItem__48528
+  .lowerBadge_e89e22:last-child
+  .numberBadge__40d6f {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.5333333333);
 }
-:root .guilds__2b93a .scroller_de945b .listItem__48528 .wrapper__8436d.selected_ae80f7 .childWrapper_a6ce15, :root .guilds__2b93a .scroller_de945b .listItem__48528 .wrapper__8436d:hover .childWrapper_a6ce15 {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .listItem__48528
+  .wrapper__8436d.selected_ae80f7
+  .childWrapper_a6ce15,
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .listItem__48528
+  .wrapper__8436d:hover
+  .childWrapper_a6ce15 {
   background: var(--main-color);
 }
-:root .guilds__2b93a .scroller_de945b .listItem__48528 .wrapper__8436d .childWrapper_a6ce15 {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .listItem__48528
+  .wrapper__8436d
+  .childWrapper_a6ce15 {
   background: var(--background-secondary);
 }
 :root .guilds__2b93a .scroller_de945b .listItem__48528 defs g:last-child {
@@ -669,22 +789,51 @@
 :root .guilds__2b93a .scroller_de945b .wrapper__832f2 {
   width: 90px;
 }
-:root .guilds__2b93a .scroller_de945b .wrapper__832f2 .expandedFolderBackground_b1385f {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .wrapper__832f2
+  .expandedFolderBackground_b1385f {
   left: 21px;
 }
-:root .guilds__2b93a .scroller_de945b .wrapper__832f2 .folderIconWrapper__11165 {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .wrapper__832f2
+  .folderIconWrapper__11165 {
   transition: border-radius 200ms;
 }
-:root .guilds__2b93a .scroller_de945b .wrapper__832f2 .folderIconWrapper__11165:hover {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .wrapper__832f2
+  .folderIconWrapper__11165:hover {
   border-radius: 12px;
 }
-:root .guilds__2b93a .scroller_de945b .wrapper__832f2 .wrapper__9916c > svg > foreignObject {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .wrapper__832f2
+  .wrapper__9916c
+  > svg
+  > foreignObject {
   mask: none;
 }
-:root .guilds__2b93a .scroller_de945b .wrapper__832f2 .wrapper__9916c > svg > foreignObject .folder__17546 {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .wrapper__832f2
+  .wrapper__9916c
+  > svg
+  > foreignObject
+  .folder__17546 {
   background: transparent;
 }
-:root .guilds__2b93a .scroller_de945b .wrapper__832f2.expanded .expandedFolderBackground_b1385f {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .wrapper__832f2.expanded
+  .expandedFolderBackground_b1385f {
   background: var(--background-secondary);
 }
 :root .guilds__2b93a .scroller_de945b .circleIconButton__05cf2 {
@@ -694,15 +843,47 @@
   color: var(--epicshadow1);
   transition: all 0.2s;
 }
-:root .guilds__2b93a .scroller_de945b .tutorialContainer__6835f:hover .circleIconButton__05cf2, :root .guilds__2b93a .scroller_de945b .tutorialContainer__6835f + .listItem__48528:hover .circleIconButton__05cf2 {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .tutorialContainer__6835f:hover
+  .circleIconButton__05cf2,
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .tutorialContainer__6835f
+  + .listItem__48528:hover
+  .circleIconButton__05cf2 {
   background: transparent;
   color: var(--main-color);
   border-color: var(--main-color);
 }
-:root .guilds__2b93a .scroller_de945b .tutorialContainer__6835f .wrapperSimple__9e2b0, :root .guilds__2b93a .scroller_de945b .tutorialContainer__6835f + .listItem__48528 .wrapperSimple__9e2b0 {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .tutorialContainer__6835f
+  .wrapperSimple__9e2b0,
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .tutorialContainer__6835f
+  + .listItem__48528
+  .wrapperSimple__9e2b0 {
   overflow: visible;
 }
-:root .guilds__2b93a .scroller_de945b .tutorialContainer__6835f svg > foreignObject, :root .guilds__2b93a .scroller_de945b .tutorialContainer__6835f + .listItem__48528 svg > foreignObject {
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .tutorialContainer__6835f
+  svg
+  > foreignObject,
+:root
+  .guilds__2b93a
+  .scroller_de945b
+  .tutorialContainer__6835f
+  + .listItem__48528
+  svg
+  > foreignObject {
   mask: none;
 }
 :root .guilds__2b93a .scroller_de945b .wrapperSimple__9e2b0 foreignObject {
@@ -836,7 +1017,11 @@
 :root .selected__987e6 .header__77c95 {
   background: transparent;
 }
-:root .container__7e23c > .scroller__1f498 > .content__690c5 > div:first-child[style="height: 16px;"] {
+:root
+  .container__7e23c
+  > .scroller__1f498
+  > .content__690c5
+  > div:first-child[style="height: 16px;"] {
   display: none;
 }
 :root .wrapper__07e2f {
@@ -906,25 +1091,42 @@
   -webkit-app-region: unset;
 }
 :root .container__26baa.title_d4ba1a:not(.minimum__7f356) .followButton_eb1ca8,
-:root .container__26baa.title_d4ba1a:not(.minimum__7f356) .children_cde9af:after {
+:root
+  .container__26baa.title_d4ba1a:not(.minimum__7f356)
+  .children_cde9af:after {
   display: none;
 }
 :root .container__26baa.title_d4ba1a:not(.minimum__7f356) .search__07df0 {
   position: fixed;
   right: 10px;
 }
-:root .container__26baa.title_d4ba1a:not(.minimum__7f356) .search__07df0 .searchBar__5a20a {
+:root
+  .container__26baa.title_d4ba1a:not(.minimum__7f356)
+  .search__07df0
+  .searchBar__5a20a {
   background: var(--background-primary);
   width: 200px;
   height: 28px;
   padding: 2px 10px;
   border-radius: 4px;
 }
-:root .container__26baa.title_d4ba1a:not(.minimum__7f356) .search__07df0 .searchBar__5a20a .searchFilter_dbda51,
-:root .container__26baa.title_d4ba1a:not(.minimum__7f356) .search__07df0 .searchBar__5a20a .searchAnswer__2ccaf {
+:root
+  .container__26baa.title_d4ba1a:not(.minimum__7f356)
+  .search__07df0
+  .searchBar__5a20a
+  .searchFilter_dbda51,
+:root
+  .container__26baa.title_d4ba1a:not(.minimum__7f356)
+  .search__07df0
+  .searchBar__5a20a
+  .searchAnswer__2ccaf {
   background: transparent;
 }
-:root .container__26baa.title_d4ba1a:not(.minimum__7f356) .search__07df0 .searchBar__5a20a .icon__5c8c7 {
+:root
+  .container__26baa.title_d4ba1a:not(.minimum__7f356)
+  .search__07df0
+  .searchBar__5a20a
+  .icon__5c8c7 {
   color: var(--main-color);
 }
 :root .container__84c26 {
@@ -948,7 +1150,11 @@
   margin: 0;
   border-radius: 0;
 }
-:root .container__84c26 .resultsGroup_b221b0 .option__91497.selected-rZcOL-, :root .container__84c26 .resultsGroup_b221b0 .option__91497[aria-selected=true] {
+:root .container__84c26 .resultsGroup_b221b0 .option__91497.selected-rZcOL-,
+:root
+  .container__84c26
+  .resultsGroup_b221b0
+  .option__91497[aria-selected="true"] {
   background: var(--background-secondary);
 }
 :root .container__84c26 .resultsGroup_b221b0 .option__91497:after {
@@ -958,26 +1164,71 @@
   background: transparent;
   border-radius: 0;
 }
-:root .container__84c26 .calendarPicker__47c85 .react-datepicker .react-datepicker__header {
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker
+  .react-datepicker__header {
   background: transparent;
 }
-:root .container__84c26 .calendarPicker__47c85 .react-datepicker .react-datepicker__header .react-datepicker__current-month {
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker
+  .react-datepicker__header
+  .react-datepicker__current-month {
   border-bottom: none;
 }
-:root .container__84c26 .calendarPicker__47c85 .react-datepicker__navigation--next, :root .container__84c26 .calendarPicker__47c85 .react-datepicker__navigation--previous {
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker__navigation--next,
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker__navigation--previous {
   border: none;
   border-radius: 50%;
 }
-:root .container__84c26 .calendarPicker__47c85 .react-datepicker__navigation--next:hover, :root .container__84c26 .calendarPicker__47c85 .react-datepicker__navigation--previous:hover {
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker__navigation--next:hover,
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker__navigation--previous:hover {
   background-color: var(--epicshadow1);
 }
-:root .container__84c26 .calendarPicker__47c85 .react-datepicker [class^=react-datepicker__day] {
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker
+  [class^="react-datepicker__day"] {
   background: transparent;
 }
-:root .container__84c26 .calendarPicker__47c85 .react-datepicker .react-datepicker__day {
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker
+  .react-datepicker__day {
   border-color: var(--background-tertiary);
 }
-:root .container__84c26 .calendarPicker__47c85 .react-datepicker .react-datepicker__day--selected:after, :root .container__84c26 .calendarPicker__47c85 .react-datepicker .react-datepicker__day--selected:hover, :root .container__84c26 .calendarPicker__47c85 .react-datepicker .react-datepicker__day:hover {
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker
+  .react-datepicker__day--selected:after,
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker
+  .react-datepicker__day--selected:hover,
+:root
+  .container__84c26
+  .calendarPicker__47c85
+  .react-datepicker
+  .react-datepicker__day:hover {
   background: var(--main-color);
 }
 :root .container__84c26 .datePickerHint_d023b6 .hintValue__0c960 {
@@ -1014,7 +1265,10 @@
 :root .searchResultsWrap__2e184 .scroller__5f036 .pageButton_bf9853 {
   background-color: var(--background-primary);
 }
-:root .searchResultsWrap__2e184 .scroller__5f036 .pageButton_bf9853.activeButton__70b70 {
+:root
+  .searchResultsWrap__2e184
+  .scroller__5f036
+  .pageButton_bf9853.activeButton__70b70 {
   background-color: var(--main-color);
 }
 :root .recentMentionsPopout__40c54 {
@@ -1023,7 +1277,9 @@
   right: 0;
   min-height: 100%;
   max-height: 100% !important;
-  animation: sidebarStatusTransalteXReverse 0.5s ease, fade 0.4s ease;
+  animation:
+    sidebarStatusTransalteXReverse 0.5s ease,
+    fade 0.4s ease;
   border-radius: 0;
 }
 :root .recentMentionsPopout__40c54 .header__21b33 {
@@ -1037,7 +1293,11 @@
 :root .recentMentionsPopout__40c54 .header__21b33 .topPill-3DJJNV {
   margin: 0 auto;
 }
-:root .recentMentionsPopout__40c54 .header__21b33 .topPill-3DJJNV .tab_a8a066.active__7e7af {
+:root
+  .recentMentionsPopout__40c54
+  .header__21b33
+  .topPill-3DJJNV
+  .tab_a8a066.active__7e7af {
   background: var(--background-primary);
 }
 :root .recentMentionsPopout__40c54 .header__21b33 .secondary__45d4f {
@@ -1054,8 +1314,16 @@
   position: relative;
   background: transparent;
 }
-:root .recentMentionsPopout__40c54 .messagesPopout__28784 .channelHeader_ea0f89 .tertiary_ad6d80,
-:root .recentMentionsPopout__40c54 .scrollerBase_f742b2 .channelHeader_ea0f89 .tertiary_ad6d80 {
+:root
+  .recentMentionsPopout__40c54
+  .messagesPopout__28784
+  .channelHeader_ea0f89
+  .tertiary_ad6d80,
+:root
+  .recentMentionsPopout__40c54
+  .scrollerBase_f742b2
+  .channelHeader_ea0f89
+  .tertiary_ad6d80 {
   background: var(--background-primary);
 }
 :root .recentMentionsPopout__40c54 .tutorial__5bb77 {
@@ -1081,30 +1349,43 @@
   background: var(--background-primary);
   border-radius: 0;
 }
-:root .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54) .header__21b33 {
+:root
+  .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54)
+  .header__21b33 {
   background: var(--background-primary);
   text-align: center;
   box-shadow: none;
 }
-:root .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54) .messagesPopout__28784 {
+:root
+  .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54)
+  .messagesPopout__28784 {
   padding: 0 32px;
   padding-top: 5px;
 }
-:root .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54) .messagesPopout__28784 .messageGroupWrapper__1fce2 {
+:root
+  .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54)
+  .messagesPopout__28784
+  .messageGroupWrapper__1fce2 {
   border: none;
   background: var(--background-secondary);
   margin-bottom: 32px;
 }
-:root .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54) .messagesPopout__28784::-webkit-scrollbar {
+:root
+  .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54)
+  .messagesPopout__28784::-webkit-scrollbar {
   width: 8px;
   margin-left: 5px;
 }
-:root .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54) .messagesPopout__28784::-webkit-scrollbar-thumb {
+:root
+  .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54)
+  .messagesPopout__28784::-webkit-scrollbar-thumb {
   border: none;
   background: var(--background-secondary) !important;
   border-radius: 6px 0 0 6px;
 }
-:root .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54) .messagesPopout__28784::-webkit-scrollbar-track-piece {
+:root
+  .messagesPopoutWrap__10dd1:not(.recentMentionsPopout__40c54)
+  .messagesPopout__28784::-webkit-scrollbar-track-piece {
   display: none;
 }
 
@@ -1145,19 +1426,40 @@
 :root .userPopoutOuter__3884e .bannerSVGWrapper__8a38c .banner__6d414 {
   position: absolute;
   height: 200px;
-  -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.7607843137), rgba(0, 0, 0, 0.7607843137));
-  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 25px), 50% 100%, 0 calc(100% - 25px));
+  -webkit-mask-image: linear-gradient(
+    rgba(0, 0, 0, 0.7607843137),
+    rgba(0, 0, 0, 0.7607843137)
+  );
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - 25px),
+    50% 100%,
+    0 calc(100% - 25px)
+  );
 }
-:root .userPopoutOuter__3884e .bannerSVGWrapper__8a38c .banner__6d414.bannerPremium__69560 {
+:root
+  .userPopoutOuter__3884e
+  .bannerSVGWrapper__8a38c
+  .banner__6d414.bannerPremium__69560 {
   background-color: transparent !important;
 }
-:root .userPopoutOuter__3884e .bannerSVGWrapper__8a38c[viewBox="0 0 340 60"] > foreignObject {
+:root
+  .userPopoutOuter__3884e
+  .bannerSVGWrapper__8a38c[viewBox="0 0 340 60"]
+  > foreignObject {
   transform: translateY(-60px);
 }
-:root .userPopoutOuter__3884e .bannerSVGWrapper__8a38c[viewBox="0 0 340 120"] > foreignObject {
+:root
+  .userPopoutOuter__3884e
+  .bannerSVGWrapper__8a38c[viewBox="0 0 340 120"]
+  > foreignObject {
   transform: translateY(-30px);
 }
-:root .userPopoutOuter__3884e .bannerSVGWrapper__8a38c[viewBox="0 0 340 90"] > foreignObject {
+:root
+  .userPopoutOuter__3884e
+  .bannerSVGWrapper__8a38c[viewBox="0 0 340 90"]
+  > foreignObject {
   transform: translateY(-45px);
 }
 :root .userPopoutOuter__3884e .bannerSVGWrapper__8a38c > foreignObject {
@@ -1182,10 +1484,17 @@
   position: static;
   background-color: transparent;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 > .divider__126d2 {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  > .divider__126d2 {
   display: none;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .usernameSection_dd6196 .userText_c26b46 {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .usernameSection_dd6196
+  .userText_c26b46 {
   position: absolute;
   top: 110px;
   left: 0;
@@ -1193,33 +1502,67 @@
   box-sizing: border-box;
   text-align: center;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .usernameSection_dd6196 .userText_c26b46 .discrimBase__5555e {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .usernameSection_dd6196
+  .userText_c26b46
+  .discrimBase__5555e {
   color: white;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .pronouns__8aa38 {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .pronouns__8aa38 {
   position: relative;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .scroller_f9a667::-webkit-scrollbar {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .scroller_f9a667::-webkit-scrollbar {
   display: none;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .activity__20c1e {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .activity__20c1e {
   z-index: 1;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .activity__20c1e .assetsLargeImageSpotify__3df69 {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .activity__20c1e
+  .assetsLargeImageSpotify__3df69 {
   border-radius: 8px !important;
   margin-left: 6px;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .activity__20c1e .content__7246b {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .activity__20c1e
+  .content__7246b {
   margin-right: 8px;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .activity__20c1e .button__88ad4 {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .activity__20c1e
+  .button__88ad4 {
   background-color: var(--main-color);
   opacity: 1;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .activity__20c1e .platformIcon_a2d873 {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .activity__20c1e
+  .platformIcon_a2d873 {
   display: none;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .activity__20c1e .timeBarUserPopoutV2__5d401 {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .activity__20c1e
+  .timeBarUserPopoutV2__5d401 {
   position: absolute;
   top: 7px;
   left: 0;
@@ -1228,21 +1571,41 @@
   height: 70px;
   border-radius: 8px;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .activity__20c1e .timeBarUserPopoutV2__5d401 .bar_e63719 {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .activity__20c1e
+  .timeBarUserPopoutV2__5d401
+  .bar_e63719 {
   border-radius: 8px;
   height: 100%;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .activity__20c1e .timeBarUserPopoutV2__5d401 .barInner__0f713 {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .activity__20c1e
+  .timeBarUserPopoutV2__5d401
+  .barInner__0f713 {
   border-radius: 8px 0 0 8px;
   opacity: 0.2;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .activity__20c1e .timeBarUserPopoutV2__5d401 > :last-child {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .activity__20c1e
+  .timeBarUserPopoutV2__5d401
+  > :last-child {
   display: none;
 }
-:root .userPopoutOuter__3884e .userPopoutOverlayBackground_bf6444 .input-2g-os5 {
+:root
+  .userPopoutOuter__3884e
+  .userPopoutOverlayBackground_bf6444
+  .input-2g-os5 {
   background-color: transparent !important;
 }
-:root .userPopoutOuter__3884e.userProfileOuterThemed__1fbd7 .usernameSection_dd6196 {
+:root
+  .userPopoutOuter__3884e.userProfileOuterThemed__1fbd7
+  .usernameSection_dd6196 {
   left: 4px;
 }
 :root .userPopoutOuter__3884e .avatarWrapper__0cd44 {
@@ -1254,14 +1617,28 @@
   left: 0;
   border-radius: calc(var(--avatar-radius) * 2) !important;
 }
-:root .userPopoutOuter__3884e .avatarWrapper__0cd44 .avatarHint__15059 foreignObject {
+:root
+  .userPopoutOuter__3884e
+  .avatarWrapper__0cd44
+  .avatarHint__15059
+  foreignObject {
   mask: none !important;
 }
-:root .userPopoutOuter__3884e .avatarWrapper__0cd44 .avatarHint__15059 foreignObject .avatarHintInner_c8ddb1 {
+:root
+  .userPopoutOuter__3884e
+  .avatarWrapper__0cd44
+  .avatarHint__15059
+  foreignObject
+  .avatarHintInner_c8ddb1 {
   font-size: 0;
   text-transform: none;
 }
-:root .userPopoutOuter__3884e .avatarWrapper__0cd44 .avatarHint__15059 foreignObject .avatarHintInner_c8ddb1::after {
+:root
+  .userPopoutOuter__3884e
+  .avatarWrapper__0cd44
+  .avatarHint__15059
+  foreignObject
+  .avatarHintInner_c8ddb1::after {
   white-space: normal;
   text-align: center;
   content: var(--avatar-hint-text);
@@ -1273,14 +1650,15 @@
   border-radius: calc(var(--avatar-radius) * 2) !important;
 }
 :root .userPopoutOuter__3884e .mask_d5067d circle,
-:root .userPopoutOuter__3884e .mask_d5067d rect[fill=black] {
+:root .userPopoutOuter__3884e .mask_d5067d rect[fill="black"] {
   display: none;
 }
 :root .root_ba16f0.root_a28985.small_f8e677 {
   width: 800px;
   height: 100%;
 }
-:root .root_ba16f0.root_a28985.small_f8e677 > div, :root .root_ba16f0.root_a28985.small_f8e677 .userProfileModalOuter_a65559 {
+:root .root_ba16f0.root_a28985.small_f8e677 > div,
+:root .root_ba16f0.root_a28985.small_f8e677 .userProfileModalOuter_a65559 {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
@@ -1308,13 +1686,20 @@
   width: 100%;
   height: 100%;
 }
-:root .userProfileModalInner__99b1e .topSection__2d8b8 .bannerSVGWrapper__8a38c {
+:root
+  .userProfileModalInner__99b1e
+  .topSection__2d8b8
+  .bannerSVGWrapper__8a38c {
   min-width: unset !important;
   min-height: unset !important;
   width: 100%;
   height: 100%;
 }
-:root .userProfileModalInner__99b1e .topSection__2d8b8 .bannerSVGWrapper__8a38c .banner__6d414 {
+:root
+  .userProfileModalInner__99b1e
+  .topSection__2d8b8
+  .bannerSVGWrapper__8a38c
+  .banner__6d414 {
   position: absolute;
   top: 0;
   left: 0;
@@ -1323,32 +1708,70 @@
   z-index: -1;
   opacity: 0.6;
   border-radius: 10px 0 0 10px;
-  mask-image: linear-gradient(90deg, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.2862745098));
-  -webkit-mask-image: linear-gradient(90deg, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.2862745098));
+  mask-image: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.8),
+    rgba(0, 0, 0, 0.2862745098)
+  );
+  -webkit-mask-image: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.8),
+    rgba(0, 0, 0, 0.2862745098)
+  );
 }
-:root .userProfileModalInner__99b1e .topSection__2d8b8 .bannerSVGWrapper__8a38c > foreignObject {
+:root
+  .userProfileModalInner__99b1e
+  .topSection__2d8b8
+  .bannerSVGWrapper__8a38c
+  > foreignObject {
   mask: none;
 }
-:root .userProfileModalInner__99b1e .topSection__2d8b8 .bannerSVGWrapper__8a38c[viewBox="0 0 600 106"] > foreignObject {
+:root
+  .userProfileModalInner__99b1e
+  .topSection__2d8b8
+  .bannerSVGWrapper__8a38c[viewBox="0 0 600 106"]
+  > foreignObject {
   y: -350px;
   height: 800px;
 }
-:root .userProfileModalInner__99b1e .topSection__2d8b8 .bannerSVGWrapper__8a38c[viewBox="0 0 600 212"] > foreignObject {
+:root
+  .userProfileModalInner__99b1e
+  .topSection__2d8b8
+  .bannerSVGWrapper__8a38c[viewBox="0 0 600 212"]
+  > foreignObject {
   y: -250px;
   height: 700px;
 }
 :root .userProfileModalInner__99b1e .topSection__2d8b8 .header_dda341 {
   position: static;
 }
-:root .userProfileModalInner__99b1e .topSection__2d8b8 .header_dda341 .avatar__445f3 {
+:root
+  .userProfileModalInner__99b1e
+  .topSection__2d8b8
+  .header_dda341
+  .avatar__445f3 {
   top: 16px;
   left: 16px;
 }
-:root .userProfileModalInner__99b1e .topSection__2d8b8 .header_dda341 .avatar__445f3 circle,
-:root .userProfileModalInner__99b1e .topSection__2d8b8 .header_dda341 .avatar__445f3 rect[fill=black] {
+:root
+  .userProfileModalInner__99b1e
+  .topSection__2d8b8
+  .header_dda341
+  .avatar__445f3
+  circle,
+:root
+  .userProfileModalInner__99b1e
+  .topSection__2d8b8
+  .header_dda341
+  .avatar__445f3
+  rect[fill="black"] {
   display: none;
 }
-:root .userProfileModalInner__99b1e .topSection__2d8b8 .header_dda341 .badgeList__126b0 {
+:root
+  .userProfileModalInner__99b1e
+  .topSection__2d8b8
+  .header_dda341
+  .badgeList__126b0 {
   position: absolute;
   top: 65px;
   left: -15px;
@@ -1374,19 +1797,33 @@
   box-sizing: border-box;
   border-bottom-right-radius: 5px;
 }
-:root .userProfileModalInner__99b1e .customStatusText__358c7.activityProfile__5d0ec {
+:root
+  .userProfileModalInner__99b1e
+  .customStatusText__358c7.activityProfile__5d0ec {
   right: unset;
   bottom: -140px;
   left: 5px;
   width: 750px;
   padding: 20px;
 }
-:root .userProfileModalInner__99b1e .customStatusText__358c7 .customStatus__928b7 {
+:root
+  .userProfileModalInner__99b1e
+  .customStatusText__358c7
+  .customStatus__928b7 {
   margin-top: 0;
 }
-:root .userProfileModalInner__99b1e .customStatusText__358c7 .assetsLargeImageActivityFeed__56b16,
-:root .userProfileModalInner__99b1e .customStatusText__358c7 .assetsLargeImageActivityFeedXbox_a24562,
-:root .userProfileModalInner__99b1e .customStatusText__358c7 .assetsLargeImageProfile__8a5b1 {
+:root
+  .userProfileModalInner__99b1e
+  .customStatusText__358c7
+  .assetsLargeImageActivityFeed__56b16,
+:root
+  .userProfileModalInner__99b1e
+  .customStatusText__358c7
+  .assetsLargeImageActivityFeedXbox_a24562,
+:root
+  .userProfileModalInner__99b1e
+  .customStatusText__358c7
+  .assetsLargeImageProfile__8a5b1 {
   width: 40px;
   height: 40px;
 }
@@ -1398,59 +1835,115 @@
   background-color: var(--background-primary);
   border-radius: 0;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .container__9f51c > div:first-child {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .container__9f51c
+  > div:first-child {
   position: absolute;
   top: 25px;
   left: 153px;
   z-index: 1;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .container__9f51c > div:first-child > span {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .container__9f51c
+  > div:first-child
+  > span {
   max-width: 200px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .container__9f51c {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .container__9f51c {
   padding: 0;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .divider__7116f {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .divider__7116f {
   display: none;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .pronouns__3d468 {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .pronouns__3d468 {
   position: absolute;
   left: 153px;
   top: 112px;
   z-index: 1;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .tabBarContainer_b283be {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .tabBarContainer_b283be {
   position: absolute;
   bottom: 65px;
   left: 5px;
   z-index: 1;
   border-bottom: unset;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .tabBarContainer_b283be .tabBar__35f81 {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .tabBarContainer_b283be
+  .tabBar__35f81 {
   flex-direction: column;
   gap: 15px;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .tabBarContainer_b283be .tabBar__35f81 .item__48dda {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .tabBarContainer_b283be
+  .tabBar__35f81
+  .item__48dda {
   height: 20px;
   border-bottom: unset;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .connectedAccounts__7a8e6 {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .connectedAccounts__7a8e6 {
   padding-bottom: 80px;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .connectedAccounts__7a8e6 .connectedAccountContainer__5972d {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .connectedAccounts__7a8e6
+  .connectedAccountContainer__5972d {
   border: none;
   border-radius: 8px;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .listScroller__18a19 {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .listScroller__18a19 {
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: repeat(20, 0fr);
   gap: 10px;
   padding-left: 8px;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .listScroller__18a19 .listRow__50619 {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .listScroller__18a19
+  .listRow__50619 {
   position: relative;
   z-index: 1;
   height: 44px;
@@ -1460,7 +1953,13 @@
   overflow: hidden;
   background-color: rgba(255, 255, 255, 0.0274509804);
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .listScroller__18a19 .listRow__50619 .listAvatar__67297 {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .listScroller__18a19
+  .listRow__50619
+  .listAvatar__67297 {
   position: absolute;
   right: 0;
   z-index: -1;
@@ -1468,21 +1967,53 @@
   height: 250% !important;
   margin-right: 0;
   border-radius: 0;
-  -webkit-mask-image: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.7960784314));
+  -webkit-mask-image: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0),
+    rgba(0, 0, 0, 0.7960784314)
+  );
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .listScroller__18a19 .listRow__50619 .listAvatar__67297 svg {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .listScroller__18a19
+  .listRow__50619
+  .listAvatar__67297
+  svg {
   position: relative;
   width: 100%;
   height: 100%;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .listScroller__18a19 .listRow__50619 .listAvatar__67297 svg foreignObject {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .listScroller__18a19
+  .listRow__50619
+  .listAvatar__67297
+  svg
+  foreignObject {
   width: 100%;
   height: 100%;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .listScroller__18a19 .listRow__50619 .listAvatar__67297 svg rect {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .listScroller__18a19
+  .listRow__50619
+  .listAvatar__67297
+  svg
+  rect {
   display: none;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .listScroller__18a19 .empty__18e40 {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .listScroller__18a19
+  .empty__18e40 {
   grid-column: 1/3;
   grid-row: 1/22;
   position: relative;
@@ -1492,7 +2023,13 @@
   padding-left: 10px;
   border-radius: 8px;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .listScroller__18a19 .empty__18e40 .emptyIconFriends_b554b1 {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .listScroller__18a19
+  .empty__18e40
+  .emptyIconFriends_b554b1 {
   position: absolute;
   z-index: -1;
   width: 80%;
@@ -1501,10 +2038,19 @@
   opacity: 0.2;
   background-size: 100%;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .listScroller__18a19 .activityProfileV2_f5335f {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .listScroller__18a19
+  .activityProfileV2_f5335f {
   grid-column: 1/3;
 }
-:root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 .body_bd4552 .input-2g-os5 {
+:root
+  .userProfileModalInner__99b1e
+  .userProfileModalOverlayBackground__7ec35
+  .body_bd4552
+  .input-2g-os5 {
   background-color: transparent;
 }
 :root .userProfileModalInner__99b1e .userProfileModalOverlayBackground__7ec35 {
@@ -1531,36 +2077,89 @@
   justify-content: flex-start;
   border-radius: 8px 0 0;
 }
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e .sidebar__02e8d {
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e
+  .sidebar__02e8d {
   width: 240px;
 }
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e .sidebar__02e8d .side_b4b3f6 .header__71a82 {
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e
+  .sidebar__02e8d
+  .side_b4b3f6
+  .header__71a82 {
   color: var(--textcolor);
 }
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e .sidebar__02e8d .bd-sidebar-header-label {
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e
+  .sidebar__02e8d
+  .bd-sidebar-header-label {
   color: var(--textcolor);
   padding: 0;
 }
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e .sidebar__02e8d .side_b4b3f6 .header__71a82,
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e .sidebar__02e8d .side_b4b3f6 .item__48dda,
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e .sidebar__02e8d .bd-sidebar-header {
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e
+  .sidebar__02e8d
+  .side_b4b3f6
+  .header__71a82,
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e
+  .sidebar__02e8d
+  .side_b4b3f6
+  .item__48dda,
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e
+  .sidebar__02e8d
+  .bd-sidebar-header {
   padding: 6px 30px;
   border-radius: 0;
 }
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e .sidebar__02e8d .socialLinks_dbdd6f {
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e
+  .sidebar__02e8d
+  .socialLinks_dbdd6f {
   justify-content: center;
   display: flex;
   flex-direction: row;
 }
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e .sidebar__02e8d .info__755e1 {
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e
+  .sidebar__02e8d
+  .info__755e1 {
   padding-left: 30px;
 }
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e .sidebar__02e8d,
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e .flexChild__3da10 {
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e
+  .sidebar__02e8d,
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e
+  .flexChild__3da10 {
   padding-left: 0 !important;
   padding-right: 0 !important;
 }
-:root .layer_f7d46a .sidebarRegion__36437 .sidebarRegionScroller__8113e::-webkit-scrollbar {
+:root
+  .layer_f7d46a
+  .sidebarRegion__36437
+  .sidebarRegionScroller__8113e::-webkit-scrollbar {
   display: none;
 }
 :root .layer_f7d46a .contentColumn__5f80b,
@@ -1635,7 +2234,10 @@
   y: -110px;
 }
 :root .accountProfileCard__744d8 .banner__6d414 {
-  -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.7607843137), rgba(0, 0, 0, 0.7607843137));
+  -webkit-mask-image: linear-gradient(
+    rgba(0, 0, 0, 0.7607843137),
+    rgba(0, 0, 0, 0.7607843137)
+  );
   border-radius: 8px 0 0 8px;
   height: 320px;
   flex: 1;
@@ -1678,32 +2280,63 @@
 :root .profileCustomizationSection_c4a87a .baseLayout_a5adfd > :first-child {
   flex: 2 auto;
 }
-:root .profileCustomizationSection_c4a87a .baseLayout_a5adfd .userPopoutInner_e90432:before {
+:root
+  .profileCustomizationSection_c4a87a
+  .baseLayout_a5adfd
+  .userPopoutInner_e90432:before {
   width: calc(100% - 8px) !important;
 }
 :root .profileCustomizationSection_c4a87a .baseLayout_a5adfd .banner_b7f1fb {
   position: absolute;
   left: 0;
   height: 200px;
-  -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.7607843137), rgba(0, 0, 0, 0.7607843137));
-  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 25px), 50% 100%, 0 calc(100% - 25px));
+  -webkit-mask-image: linear-gradient(
+    rgba(0, 0, 0, 0.7607843137),
+    rgba(0, 0, 0, 0.7607843137)
+  );
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - 25px),
+    50% 100%,
+    0 calc(100% - 25px)
+  );
 }
-:root .profileCustomizationSection_c4a87a .baseLayout_a5adfd .avatarUploader__1f1a2 {
+:root
+  .profileCustomizationSection_c4a87a
+  .baseLayout_a5adfd
+  .avatarUploader__1f1a2 {
   top: 15px;
   left: 50%;
   margin-left: -40px;
 }
-:root .profileCustomizationSection_c4a87a .baseLayout_a5adfd .avatarUploader__1f1a2 .avatarUploaderInner__71578 {
+:root
+  .profileCustomizationSection_c4a87a
+  .baseLayout_a5adfd
+  .avatarUploader__1f1a2
+  .avatarUploaderInner__71578 {
   border: none;
   border-radius: var(--avatar-radius);
 }
-:root .profileCustomizationSection_c4a87a .baseLayout_a5adfd .avatarUploader__1f1a2 .imageUploaderIcon__4b7d2 {
+:root
+  .profileCustomizationSection_c4a87a
+  .baseLayout_a5adfd
+  .avatarUploader__1f1a2
+  .imageUploaderIcon__4b7d2 {
   display: none;
 }
-:root .profileCustomizationSection_c4a87a .baseLayout_a5adfd .avatarUploader__1f1a2 .status_be3f03 {
+:root
+  .profileCustomizationSection_c4a87a
+  .baseLayout_a5adfd
+  .avatarUploader__1f1a2
+  .status_be3f03 {
   background-color: transparent;
 }
-:root .profileCustomizationSection_c4a87a .baseLayout_a5adfd .section__62b44 .userText_c26b46 {
+:root
+  .profileCustomizationSection_c4a87a
+  .baseLayout_a5adfd
+  .section__62b44
+  .userText_c26b46 {
   position: absolute;
   top: 110px;
   left: 0;
@@ -1711,10 +2344,18 @@
   box-sizing: border-box;
   text-align: center;
 }
-:root .profileCustomizationSection_c4a87a .baseLayout_a5adfd .section__62b44 .userText_c26b46 .discrimBase__5555e {
+:root
+  .profileCustomizationSection_c4a87a
+  .baseLayout_a5adfd
+  .section__62b44
+  .userText_c26b46
+  .discrimBase__5555e {
   color: white;
 }
-:root .profileCustomizationSection_c4a87a .baseLayout_a5adfd .customStatus__3aa7f {
+:root
+  .profileCustomizationSection_c4a87a
+  .baseLayout_a5adfd
+  .customStatus__3aa7f {
   padding-top: 12px;
 }
 :root .profileCustomizationSection_c4a87a .baseLayout_a5adfd .divider-1wtgZ3 {
@@ -1767,7 +2408,10 @@
   background: transparent;
   backdrop-filter: blur(5px);
 }
-:root .cardWrapper_bc8d2a .gemIndicatorContainer_b03ca0 .gemWithoutLabel__6225b {
+:root
+  .cardWrapper_bc8d2a
+  .gemIndicatorContainer_b03ca0
+  .gemWithoutLabel__6225b {
   color: #999;
 }
 :root .cardWrapper_bc8d2a .icon__94164 {
@@ -1823,7 +2467,8 @@
 :root .gameNameInput__3e1e4 {
   padding: 8px;
 }
-:root .gameNameInput__3e1e4:focus, :root .gameNameInput__3e1e4:hover {
+:root .gameNameInput__3e1e4:focus,
+:root .gameNameInput__3e1e4:hover {
   background-color: var(--background-primary);
   border: none;
 }
@@ -1844,7 +2489,10 @@
   background: var(--main-color);
   opacity: 0.4;
 }
-:root .notificationSettings-1U0JsJ .wrapper__4b6b3 .option__1d8de.selected__4e154 {
+:root
+  .notificationSettings-1U0JsJ
+  .wrapper__4b6b3
+  .option__1d8de.selected__4e154 {
   background: var(--main-color);
   box-shadow: unset;
 }
@@ -1877,7 +2525,10 @@
   border: none;
   border-radius: 8px;
 }
-:root .customColorPicker_bbc020 .customColorPickerInputContainer_e467bb .input_f27786 {
+:root
+  .customColorPicker_bbc020
+  .customColorPickerInputContainer_e467bb
+  .input_f27786 {
   background-color: var(--background-secondary);
 }
 :root .emojiAliasInput-1y-NBz .emojiInput-1aLNse {
@@ -1957,13 +2608,20 @@
 :root .panels__58331 > .container_debb33 {
   padding: 10px 8px;
 }
-:root .panels__58331 > .container_debb33 .avatarWrapper__500a6[aria-expanded] .wrapper__3ed10 {
+:root
+  .panels__58331
+  > .container_debb33
+  .avatarWrapper__500a6[aria-expanded]
+  .wrapper__3ed10 {
   position: fixed;
   left: 29px;
   bottom: 23px;
   z-index: 1;
 }
-:root .panels__58331 > .container_debb33 .avatarWrapper__500a6[aria-expanded]:hover {
+:root
+  .panels__58331
+  > .container_debb33
+  .avatarWrapper__500a6[aria-expanded]:hover {
   background-color: transparent;
 }
 :root .panels__58331 > .container_debb33 .title-3XlmeX {
@@ -1972,7 +2630,10 @@
 :root .panels__58331 > .container_debb33 .button_ae40a4 {
   color: #888;
 }
-:root .panels__58331 > .container_debb33 .button_ae40a4[aria-checked=false].enabled__214db {
+:root
+  .panels__58331
+  > .container_debb33
+  .button_ae40a4[aria-checked="false"].enabled__214db {
   color: var(--main-color);
 }
 :root .noChat_ce920d.wrapper__6bf2d {
@@ -1985,7 +2646,9 @@
   width: unset;
 }
 :root .noChat_ce920d.wrapper__6bf2d .border_d9a17b.speaking_c28527 {
-  box-shadow: inset 0 0 0 2.5px #43b581, inset 0 0 0 4.5px var(--background-secondary);
+  box-shadow:
+    inset 0 0 0 2.5px #43b581,
+    inset 0 0 0 4.5px var(--background-secondary);
 }
 :root .noChat_ce920d.wrapper__6bf2d .wrapper__4d4fe .button__581d0 {
   border-radius: 50%;
@@ -2065,36 +2728,85 @@
   background: var(--background-secondary);
   border-radius: 15px 0 0 15px;
 }
-:root .container_bd15da .nowPlayingColumn_b025fe .container__3673d .scroller__7c25e {
+:root
+  .container_bd15da
+  .nowPlayingColumn_b025fe
+  .container__3673d
+  .scroller__7c25e {
   border: none;
   padding: 16px 0 !important;
   margin: 0;
 }
-:root .container_bd15da .nowPlayingColumn_b025fe .container__3673d .scroller__7c25e .header_c56a27 {
+:root
+  .container_bd15da
+  .nowPlayingColumn_b025fe
+  .container__3673d
+  .scroller__7c25e
+  .header_c56a27 {
   text-align: center;
 }
-:root .container_bd15da .nowPlayingColumn_b025fe .container__3673d .scroller__7c25e .emptyCard__204d9 {
+:root
+  .container_bd15da
+  .nowPlayingColumn_b025fe
+  .container__3673d
+  .scroller__7c25e
+  .emptyCard__204d9 {
   margin: 16px;
 }
-:root .container_bd15da .nowPlayingColumn_b025fe .container__3673d .scroller__7c25e .outer_a41cf3 {
+:root
+  .container_bd15da
+  .nowPlayingColumn_b025fe
+  .container__3673d
+  .scroller__7c25e
+  .outer_a41cf3 {
   background: transparent;
 }
-:root .container_bd15da .nowPlayingColumn_b025fe .container__3673d .scroller__7c25e .wrapper__3c6d5 {
+:root
+  .container_bd15da
+  .nowPlayingColumn_b025fe
+  .container__3673d
+  .scroller__7c25e
+  .wrapper__3c6d5 {
   background: var(--background-secondary);
   margin: 16px;
   border-radius: 10px;
   border: none;
 }
-:root .container_bd15da .nowPlayingColumn_b025fe .container__3673d .scroller__7c25e .wrapper__3c6d5 .body__616e6 > :nth-last-child(3) {
+:root
+  .container_bd15da
+  .nowPlayingColumn_b025fe
+  .container__3673d
+  .scroller__7c25e
+  .wrapper__3c6d5
+  .body__616e6
+  > :nth-last-child(3) {
   border-radius: 8px 8px 0 0;
 }
-:root .container_bd15da .nowPlayingColumn_b025fe .container__3673d .scroller__7c25e .wrapper__3c6d5 .body__616e6 .separator_fc3370 {
+:root
+  .container_bd15da
+  .nowPlayingColumn_b025fe
+  .container__3673d
+  .scroller__7c25e
+  .wrapper__3c6d5
+  .body__616e6
+  .separator_fc3370 {
   display: none;
 }
-:root .container_bd15da .nowPlayingColumn_b025fe .container__3673d .scroller__7c25e .wrapper__3c6d5 .body__616e6 > :nth-child(3) {
+:root
+  .container_bd15da
+  .nowPlayingColumn_b025fe
+  .container__3673d
+  .scroller__7c25e
+  .wrapper__3c6d5
+  .body__616e6
+  > :nth-child(3) {
   border-radius: 0 0 8px 8px;
 }
-:root .container_bd15da .nowPlayingColumn_b025fe .container__3673d .scroller__7c25e::-webkit-scrollbar {
+:root
+  .container_bd15da
+  .nowPlayingColumn_b025fe
+  .container__3673d
+  .scroller__7c25e::-webkit-scrollbar {
   display: none;
 }
 :root .akaBadge__27cd4 {
@@ -2118,13 +2830,20 @@
   background: var(--background-primary);
 }
 :root .wrapper__6bf2d:not(.video__004a2) .border_e782de.speaking_b20122 {
-  box-shadow: inset 0 0 0 2.5px #43b581, inset 0 0 0 6px var(--background-secondary);
+  box-shadow:
+    inset 0 0 0 2.5px #43b581,
+    inset 0 0 0 6px var(--background-secondary);
 }
 :root .wrapper__6bf2d:not(.video__004a2) .colorable__4f530.primaryDark_ec74a7,
 :root .wrapper__6bf2d:not(.video__004a2) .leftTrayIcon_e01f72 {
   background: var(--background-primary);
 }
-:root .wrapper__6bf2d:not(.video__004a2) .wrapper__4d4fe > .controlButton__863c7 > svg > foreignObject {
+:root
+  .wrapper__6bf2d:not(.video__004a2)
+  .wrapper__4d4fe
+  > .controlButton__863c7
+  > svg
+  > foreignObject {
   mask: none;
 }
 :root .quickSelectPopout__56a98 {
@@ -2149,16 +2868,34 @@
 :root .userPanelOuter_eb00b1 .bannerSVGWrapper__8a38c .banner__6d414 {
   position: absolute;
   height: 200px;
-  -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.7607843137), rgba(0, 0, 0, 0.7607843137));
-  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 25px), 50% 100%, 0 calc(100% - 25px));
+  -webkit-mask-image: linear-gradient(
+    rgba(0, 0, 0, 0.7607843137),
+    rgba(0, 0, 0, 0.7607843137)
+  );
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - 25px),
+    50% 100%,
+    0 calc(100% - 25px)
+  );
 }
-:root .userPanelOuter_eb00b1 .bannerSVGWrapper__8a38c[viewBox="0 0 340 60"] > foreignObject {
+:root
+  .userPanelOuter_eb00b1
+  .bannerSVGWrapper__8a38c[viewBox="0 0 340 60"]
+  > foreignObject {
   transform: translateY(-60px);
 }
-:root .userPanelOuter_eb00b1 .bannerSVGWrapper__8a38c[viewBox="0 0 340 120"] > foreignObject {
+:root
+  .userPanelOuter_eb00b1
+  .bannerSVGWrapper__8a38c[viewBox="0 0 340 120"]
+  > foreignObject {
   transform: translateY(-30px);
 }
-:root .userPanelOuter_eb00b1 .bannerSVGWrapper__8a38c[viewBox="0 0 340 90"] > foreignObject {
+:root
+  .userPanelOuter_eb00b1
+  .bannerSVGWrapper__8a38c[viewBox="0 0 340 90"]
+  > foreignObject {
   transform: translateY(-45px);
 }
 :root .userPanelOuter_eb00b1 .bannerSVGWrapper__8a38c > foreignObject {
@@ -2188,7 +2925,11 @@
 :root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) {
   position: static;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .section__62b44 .userText_c26b46 {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .section__62b44
+  .userText_c26b46 {
   position: absolute;
   top: 110px;
   left: 0;
@@ -2196,34 +2937,68 @@
   box-sizing: border-box;
   text-align: center;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .section__62b44 .userText_c26b46 .discrimBase__5555e {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .section__62b44
+  .userText_c26b46
+  .discrimBase__5555e {
   color: white;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .pronouns__8aa38 {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .pronouns__8aa38 {
   position: relative;
   margin-top: 8px;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .scroller_f9a667::-webkit-scrollbar {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .scroller_f9a667::-webkit-scrollbar {
   display: none;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .activity__20c1e {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .activity__20c1e {
   z-index: 1;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .activity__20c1e .assetsLargeImageSpotify__3df69 {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .activity__20c1e
+  .assetsLargeImageSpotify__3df69 {
   border-radius: 8px !important;
   margin-left: 6px;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .activity__20c1e .content__7246b {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .activity__20c1e
+  .content__7246b {
   margin-right: 8px;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .activity__20c1e .button__88ad4 {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .activity__20c1e
+  .button__88ad4 {
   background-color: var(--main-color);
   opacity: 1;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .activity__20c1e .platformIcon_a2d873 {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .activity__20c1e
+  .platformIcon_a2d873 {
   display: none;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .activity__20c1e .timeBarUserPopoutV2__5d401 {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .activity__20c1e
+  .timeBarUserPopoutV2__5d401 {
   position: absolute;
   top: 7px;
   left: 0;
@@ -2232,21 +3007,41 @@
   height: 70px;
   border-radius: 8px;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .activity__20c1e .timeBarUserPopoutV2__5d401 .bar_e63719 {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .activity__20c1e
+  .timeBarUserPopoutV2__5d401
+  .bar_e63719 {
   border-radius: 8px;
   height: 100%;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .activity__20c1e .timeBarUserPopoutV2__5d401 .barInner__0f713 {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .activity__20c1e
+  .timeBarUserPopoutV2__5d401
+  .barInner__0f713 {
   border-radius: 8px 0 0 8px;
   opacity: 0.2;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .activity__20c1e .timeBarUserPopoutV2__5d401 > :last-child {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .activity__20c1e
+  .timeBarUserPopoutV2__5d401
+  > :last-child {
   display: none;
 }
-:root .userPanelOuter_eb00b1 .userPanelOverlayBackground__41589:nth-child(2) .input-2g-os5 {
+:root
+  .userPanelOuter_eb00b1
+  .userPanelOverlayBackground__41589:nth-child(2)
+  .input-2g-os5 {
   background-color: transparent !important;
 }
-:root .userPanelOuter_eb00b1.userProfileOuterThemed__1fbd7 .usernameSection_dd6196 {
+:root
+  .userPanelOuter_eb00b1.userProfileOuterThemed__1fbd7
+  .usernameSection_dd6196 {
   left: 4px;
 }
 :root .userPanelOuter_eb00b1 .avatarWrapper__0cd44 {
@@ -2258,14 +3053,28 @@
   left: 0;
   border-radius: calc(var(--avatar-radius) * 2) !important;
 }
-:root .userPanelOuter_eb00b1 .avatarWrapper__0cd44 .avatarHint__15059 foreignObject {
+:root
+  .userPanelOuter_eb00b1
+  .avatarWrapper__0cd44
+  .avatarHint__15059
+  foreignObject {
   mask: none !important;
 }
-:root .userPanelOuter_eb00b1 .avatarWrapper__0cd44 .avatarHint__15059 foreignObject .avatarHintInner_c8ddb1 {
+:root
+  .userPanelOuter_eb00b1
+  .avatarWrapper__0cd44
+  .avatarHint__15059
+  foreignObject
+  .avatarHintInner_c8ddb1 {
   font-size: 0;
   text-transform: none;
 }
-:root .userPanelOuter_eb00b1 .avatarWrapper__0cd44 .avatarHint__15059 foreignObject .avatarHintInner_c8ddb1::after {
+:root
+  .userPanelOuter_eb00b1
+  .avatarWrapper__0cd44
+  .avatarHint__15059
+  foreignObject
+  .avatarHintInner_c8ddb1::after {
   white-space: normal;
   text-align: center;
   content: var(--avatar-hint-text);
@@ -2277,7 +3086,7 @@
   border-radius: calc(var(--avatar-radius) * 2) !important;
 }
 :root .userPanelOuter_eb00b1 .mask_d5067d circle,
-:root .userPanelOuter_eb00b1 .mask_d5067d rect[fill=black] {
+:root .userPanelOuter_eb00b1 .mask_d5067d rect[fill="black"] {
   display: none;
 }
 
@@ -2315,7 +3124,8 @@ body {
   left: 18px;
   width: 18px;
   height: 18px;
-  background: url("https://cdn.discordapp.com/attachments/539180316447997974/713920529622630411/aaaaaaaaa.svg") no-repeat;
+  background: url("https://cdn.discordapp.com/attachments/539180316447997974/713920529622630411/aaaaaaaaa.svg")
+    no-repeat;
   background-size: contain;
   opacity: 0;
 }
@@ -2438,7 +3248,8 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
 :root .pageWrapper_c182d3 .iconMask__4092e {
   background-color: var(--card);
 }
-:root .pageWrapper_c182d3 .card__86773:hover, :root .pageWrapper_c182d3 .card__86773:hover .iconMask__4092e,
+:root .pageWrapper_c182d3 .card__86773:hover,
+:root .pageWrapper_c182d3 .card__86773:hover .iconMask__4092e,
 :root .pageWrapper_c182d3 .iconMask__4092e:hover,
 :root .pageWrapper_c182d3 .iconMask__4092e:hover .iconMask__4092e {
   background: var(--background-secondary);
@@ -2461,30 +3272,63 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
 :root .root__6d24f .perksModal-CLcR1c .progressBar-20NUv9 .bar-1g-wqp {
   border-radius: 0;
 }
-:root .root__6d24f .perksModal-CLcR1c .progressBar-20NUv9 .tierMarkerBackground-G8FoN4 {
+:root
+  .root__6d24f
+  .perksModal-CLcR1c
+  .progressBar-20NUv9
+  .tierMarkerBackground-G8FoN4 {
   z-index: -10;
 }
-:root .root__6d24f .perksModal-CLcR1c .progressBar-20NUv9 .tierMarkerBackground-G8FoN4,
-:root .root__6d24f .perksModal-CLcR1c .progressBar-20NUv9 .barBackground-unEPDT {
+:root
+  .root__6d24f
+  .perksModal-CLcR1c
+  .progressBar-20NUv9
+  .tierMarkerBackground-G8FoN4,
+:root
+  .root__6d24f
+  .perksModal-CLcR1c
+  .progressBar-20NUv9
+  .barBackground-unEPDT {
   background: var(--background-secondary-alt-alt);
 }
-:root .root__6d24f .perksModal-CLcR1c .progressBar-20NUv9 .tierMarkerInProgress-2Tdxjz {
+:root
+  .root__6d24f
+  .perksModal-CLcR1c
+  .progressBar-20NUv9
+  .tierMarkerInProgress-2Tdxjz {
   background: var(--background-primary) !important;
 }
 :root .root__6d24f .perksModal-CLcR1c .carouselContainerVisible-bGCrdY {
   left: -15%;
 }
-:root .root__6d24f .perksModal-CLcR1c .carouselContainerVisible-bGCrdY .tierHeaderUnlocked-1IvR2R {
+:root
+  .root__6d24f
+  .perksModal-CLcR1c
+  .carouselContainerVisible-bGCrdY
+  .tierHeaderUnlocked-1IvR2R {
   background: #b377f3;
 }
-:root .root__6d24f .perksModal-CLcR1c .carouselContainerVisible-bGCrdY .tierHeaderUnlocked-1IvR2R .tierUnlocked-1yG5Ic {
+:root
+  .root__6d24f
+  .perksModal-CLcR1c
+  .carouselContainerVisible-bGCrdY
+  .tierHeaderUnlocked-1IvR2R
+  .tierUnlocked-1yG5Ic {
   background: rgba(0, 0, 0, 0.4);
   color: #fff;
 }
-:root .root__6d24f .perksModal-CLcR1c .carouselContainerVisible-bGCrdY .tierHeaderLocked-3ItHYn {
+:root
+  .root__6d24f
+  .perksModal-CLcR1c
+  .carouselContainerVisible-bGCrdY
+  .tierHeaderLocked-3ItHYn {
   background: var(--background-secondary-alt-alt);
 }
-:root .root__6d24f .perksModal-CLcR1c .carouselContainerVisible-bGCrdY .tierBody-3ju-rc {
+:root
+  .root__6d24f
+  .perksModal-CLcR1c
+  .carouselContainerVisible-bGCrdY
+  .tierBody-3ju-rc {
   background: var(--background-secondary);
 }
 :root .root__6d24f .perksModal-CLcR1c .perk-19D_HN {
@@ -2566,7 +3410,12 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
 :root #user-context-roles + .layer__6b5c3 .item__183e8 .roleRow-3HnunM {
   border-radius: 25px;
 }
-:root #user-context-roles + .layer__6b5c3 .item__183e8 .roleRow-3HnunM .roleDot-2gCDg5 {
+:root
+  #user-context-roles
+  + .layer__6b5c3
+  .item__183e8
+  .roleRow-3HnunM
+  .roleDot-2gCDg5 {
   filter: none;
   margin-right: 4px;
 }
@@ -2686,7 +3535,7 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
 :root .lookFilled__950dd.colorBrand__27d57:hover {
   background: var(--main-color) !important;
 }
-:root .item-2idW98[style*=background-color] {
+:root .item-2idW98[style*="background-color"] {
   background: var(--main-color) !important;
 }
 :root .checked__36fdc {
@@ -2779,7 +3628,9 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
   border-radius: 0;
   transition: background 200ms;
 }
-:root .item__183e8:hover, :root .item__183e8.focused_dcafb9, :root .item__183e8:active:not(.hideInteraction__0b569) {
+:root .item__183e8:hover,
+:root .item__183e8.focused_dcafb9,
+:root .item__183e8:active:not(.hideInteraction__0b569) {
   background-color: rgba(255, 255, 255, 0.05);
 }
 :root .accountProfilePopoutWrapper_d4887f {
@@ -2790,47 +3641,85 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
 :root .accountProfilePopoutWrapper_d4887f .container__0ec3c {
   background: var(--background-tertiary);
 }
-:root .accountProfilePopoutWrapper_d4887f .container__0ec3c > .ctaContainer__95bd7 {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .container__0ec3c
+  > .ctaContainer__95bd7 {
   background-color: transparent;
 }
 :root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e {
   width: 330px;
   height: 100vh;
   max-height: unset;
-  animation: sidebarStatusTransalteX 0.5s ease, fade 0.4s ease;
+  animation:
+    sidebarStatusTransalteX 0.5s ease,
+    fade 0.4s ease;
   border-radius: 0;
   background: var(--background-tertiary);
   margin-right: 0;
   padding: 0;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e .userPopoutInner_e90432 {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  .userPopoutInner_e90432 {
   height: 100vh;
   max-height: 100vh;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e .userPopoutInner_e90432::before {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  .userPopoutInner_e90432::before {
   width: 100% !important;
   height: 100% !important;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e .userProfileInnerThemedNonPremium_ed9022 {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  .userProfileInnerThemedNonPremium_ed9022 {
   background: transparent;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e .bannerSVGWrapper__8a38c .pencilContainer_ae6d25 {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  .bannerSVGWrapper__8a38c
+  .pencilContainer_ae6d25 {
   display: none;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e .avatarWrapper__0cd44 {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  .avatarWrapper__0cd44 {
   left: calc(50% - 35px);
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e .usernameSection_dd6196 .clickTarget__440f0 > .copiableField__5eae7 {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  .usernameSection_dd6196
+  .clickTarget__440f0
+  > .copiableField__5eae7 {
   padding-right: 0;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e .usernameSection_dd6196 .clickTarget__440f0 > .copiableField__5eae7 > div:last-child {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  .usernameSection_dd6196
+  .clickTarget__440f0
+  > .copiableField__5eae7
+  > div:last-child {
   display: none;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e .profileBadges__1f2ab {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  .profileBadges__1f2ab {
   top: 160px;
   width: 330px;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e .divider_d6f39c {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  .divider_d6f39c {
   display: none;
 }
 :root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e #account {
@@ -2838,23 +3727,66 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
   overflow: hidden;
   margin-top: 20px;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e #account > .scroller__8f066 {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  #account
+  > .scroller__8f066 {
   padding: 0 !important;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e #account > .scroller__8f066 #account-status-picker,
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e #account > .scroller__8f066 #account-set-custom-status,
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e #account > .scroller__8f066 #account-switch-account,
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e #account > .scroller__8f066 #account-edit-custom-status,
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e #account > .scroller__8f066 [id^=account-devmode-copy-id-] {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  #account
+  > .scroller__8f066
+  #account-status-picker,
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  #account
+  > .scroller__8f066
+  #account-set-custom-status,
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  #account
+  > .scroller__8f066
+  #account-switch-account,
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  #account
+  > .scroller__8f066
+  #account-edit-custom-status,
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  #account
+  > .scroller__8f066
+  [id^="account-devmode-copy-id-"] {
   padding: 16px;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e #account > .scroller__8f066 [id^=account-devmode-copy-id-] {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  #account
+  > .scroller__8f066
+  [id^="account-devmode-copy-id-"] {
   color: var(--interactive-hover) !important;
 }
-:root .accountProfilePopoutWrapper_d4887f .userPopoutOuter__3884e #account > .scroller__8f066::-webkit-scrollbar {
+:root
+  .accountProfilePopoutWrapper_d4887f
+  .userPopoutOuter__3884e
+  #account
+  > .scroller__8f066::-webkit-scrollbar {
   display: none;
 }
-:root div[role=group]:not(.profileGroup-1yKk23) .item__183e8.colorDefault-CDqZdO.focused_dcafb9, :root div[role=group]:not(.profileGroup-1yKk23) .item__183e8.colorDefault-CDqZdO:hover:not(.hideInteraction__0b569) {
+:root
+  div[role="group"]:not(.profileGroup-1yKk23)
+  .item__183e8.colorDefault-CDqZdO.focused_dcafb9,
+:root
+  div[role="group"]:not(.profileGroup-1yKk23)
+  .item__183e8.colorDefault-CDqZdO:hover:not(.hideInteraction__0b569) {
   background: var(--epicshadow1);
 }
 :root::-webkit-scrollbar-thumb {
@@ -2903,7 +3835,11 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
   width: fit-content;
   border: none;
 }
-:root .modal-atz_3z > .footer-1hTRRZ > .content-3nJg0c .inviteBannerUpsell-1t_LYM {
+:root
+  .modal-atz_3z
+  > .footer-1hTRRZ
+  > .content-3nJg0c
+  .inviteBannerUpsell-1t_LYM {
   order: 3;
   margin-top: 0;
 }
@@ -3071,7 +4007,9 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
 }
 :root.full-motion .translate-PeW1wK {
   transform: translateZ(0);
-  animation: zoom 0.3s ease, fade 0.3s ease;
+  animation:
+    zoom 0.3s ease,
+    fade 0.3s ease;
 }
 @keyframes sidebarStatusTransalteX {
   from {
@@ -3144,21 +4082,32 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
 :root .scale-3UGUBw.didRender-2SiRlm {
   transform: scale(1) !important;
 }
-:root #status-picker.menu__088f7 #status-picker-custom-status .labelContainer-2vJzYL {
+:root
+  #status-picker.menu__088f7
+  #status-picker-custom-status
+  .labelContainer-2vJzYL {
   padding: 0 16px;
 }
 :root #status-picker.menu__088f7 #status-picker-custom-status + .layer__6b5c3 {
   top: 432px !important;
   left: 359px !important;
 }
-:root #status-picker.menu__088f7 #status-picker-custom-status + .layer__6b5c3 .submenu-1apzyU {
+:root
+  #status-picker.menu__088f7
+  #status-picker-custom-status
+  + .layer__6b5c3
+  .submenu-1apzyU {
   background: var(--background-tertiary);
   border-radius: 0 8px 8px 0;
 }
 :root .gameActivityToggleAdded-Yd-YxC > div:last-child button:first-child {
   color: var(--main-color);
 }
-:root .activityPanel_b73e7a ~ .gameActivityToggleAdded-Yd-YxC > div:last-child button:first-child {
+:root
+  .activityPanel_b73e7a
+  ~ .gameActivityToggleAdded-Yd-YxC
+  > div:last-child
+  button:first-child {
   margin-right: 35px;
 }
 :root #MemberCount {
@@ -3192,11 +4141,20 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
   background: var(--background-secondary);
   border-bottom-width: 0px;
 }
-:root .ChannelDms-channelmembers-wrap .ChannelDms-channelmembers-header + div .membersWrap__5ca6b {
+:root
+  .ChannelDms-channelmembers-wrap
+  .ChannelDms-channelmembers-header
+  + div
+  .membersWrap__5ca6b {
   margin-top: 0;
   max-height: unset;
 }
-:root .ChannelDms-channelmembers-wrap .ChannelDms-channelmembers-header + div .membersWrap__5ca6b .members__573eb {
+:root
+  .ChannelDms-channelmembers-wrap
+  .ChannelDms-channelmembers-header
+  + div
+  .membersWrap__5ca6b
+  .members__573eb {
   padding-top: 0;
 }
 :root #channelTabs-container {
@@ -3208,7 +4166,7 @@ html:not(.platform-linux) body:not(.maximized).transparent .appMount_c99875 {
 :root #channelTabs-container ~ .layers__1c917 .guilds__2b93a {
   margin-top: -85px;
 }
-:root ul[data-list-id=guildfoldersnav] {
+:root ul[data-list-id="guildfoldersnav"] {
   margin-top: 12px;
 }
 :root .vc-addon-name-author {

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,16 @@
   "id": "nyria.couve",
   "name": "Couve",
   "description": "A new look to discord",
-  "author": {
-    "name": "A user#8169, Nyria#3863",
-    "discordID": "265924886461939712",
-    "github": "NYRI4"
-  },
+  "author": [
+    {
+      "name": "Nyria",
+      "discordID": "265924886461939712",
+      "github": "NYRI4"
+    },
+    {
+      "name": "A user#8169"
+    }
+  ],
   "version": "2.3.2",
   "updater": {
     "type": "store",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
   "author": "A user#8169, Nyria#3863",
   "license": "MIT",
   "devDependencies": {
-    "@parcel/config-default": "^2.8.3",
-    "@parcel/core": "^2.8.3",
-    "@types/node": "^18.15.11",
-    "prettier": "^2.8.7",
-    "replugged": "^4.2.3"
+    "prettier": "^3.2.5",
+    "replugged": "^4.7.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
     "build": "replugged build theme",
     "watch": "replugged build theme --watch",
     "bundle": "replugged bundle theme",
-    "lint": "prettier ./src --check",
-    "lint:fix": "prettier ./src --write"
+    "lint": "prettier ./ --check",
+    "lint:fix": "prettier ./ --write",
+    "release": "replugged release"
   },
   "author": "A user#8169, Nyria#3863",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "prettier": "^3.2.5",
     "replugged": "^4.7.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,1887 +1,550 @@
-lockfileVersion: "6.0"
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 devDependencies:
-  "@parcel/config-default":
-    specifier: ^2.8.3
-    version: 2.8.3(@parcel/core@2.8.3)
-  "@parcel/core":
-    specifier: ^2.8.3
-    version: 2.8.3
-  "@types/node":
-    specifier: ^18.15.11
-    version: 18.15.11
   prettier:
-    specifier: ^2.8.7
-    version: 2.8.7
+    specifier: ^3.2.5
+    version: 3.2.5
   replugged:
-    specifier: ^4.2.3
-    version: 4.2.3(@codemirror/view@6.9.3)(@lezer/common@1.0.2)
+    specifier: ^4.7.9
+    version: 4.7.9(@codemirror/view@6.26.1)(@lezer/common@1.2.1)
 
 packages:
-  /@babel/code-frame@7.21.4:
-    resolution:
-      {
-        integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==,
-      }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/highlight": 7.18.6
-    dev: true
 
-  /@babel/helper-validator-identifier@7.19.1:
-    resolution:
-      {
-        integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==,
-      }
-    engines: { node: ">=6.9.0" }
-    dev: true
-
-  /@babel/highlight@7.18.6:
-    resolution:
-      {
-        integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==,
-      }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/helper-validator-identifier": 7.19.1
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    dev: true
-
-  /@codemirror/autocomplete@6.4.2(@codemirror/language@6.6.0)(@codemirror/state@6.2.0)(@codemirror/view@6.9.3)(@lezer/common@1.0.2):
-    resolution:
-      {
-        integrity: sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==,
-      }
+  /@codemirror/autocomplete@6.15.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.1)(@lezer/common@1.2.1):
+    resolution: {integrity: sha512-G2Zm0mXznxz97JhaaOdoEG2cVupn4JjPaS4AcNvZzhOsnnG9YVN68VzfoUw6dYTsIxT6a/cmoFEN47KAWhXaOg==}
     peerDependencies:
-      "@codemirror/language": ^6.0.0
-      "@codemirror/state": ^6.0.0
-      "@codemirror/view": ^6.0.0
-      "@lezer/common": ^1.0.0
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      '@lezer/common': ^1.0.0
     dependencies:
-      "@codemirror/language": 6.6.0
-      "@codemirror/state": 6.2.0
-      "@codemirror/view": 6.9.3
-      "@lezer/common": 1.0.2
+      '@codemirror/language': 6.10.1
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.26.1
+      '@lezer/common': 1.2.1
     dev: true
 
-  /@codemirror/commands@6.2.2:
-    resolution:
-      {
-        integrity: sha512-s9lPVW7TxXrI/7voZ+HmD/yiAlwAYn9PH5SUVSUhsxXHhv4yl5eZ3KLntSoTynfdgVYM0oIpccQEWRBQgmNZyw==,
-      }
+  /@codemirror/commands@6.3.3:
+    resolution: {integrity: sha512-dO4hcF0fGT9tu1Pj1D2PvGvxjeGkbC6RGcZw6Qs74TH+Ed1gw98jmUgd2axWvIZEqTeTuFrg1lEB1KV6cK9h1A==}
     dependencies:
-      "@codemirror/language": 6.6.0
-      "@codemirror/state": 6.2.0
-      "@codemirror/view": 6.9.3
-      "@lezer/common": 1.0.2
+      '@codemirror/language': 6.10.1
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.26.1
+      '@lezer/common': 1.2.1
     dev: true
 
-  /@codemirror/lang-css@6.1.1(@codemirror/view@6.9.3)(@lezer/common@1.0.2):
-    resolution:
-      {
-        integrity: sha512-P6jdNEHyRcqqDgbvHYyC9Wxkek0rnG3a9aVSRi4a7WrjPbQtBTaOmvYpXmm13zZMAatO4Oqpac+0QZs7sy+LnQ==,
-      }
+  /@codemirror/lang-css@6.2.1(@codemirror/view@6.26.1):
+    resolution: {integrity: sha512-/UNWDNV5Viwi/1lpr/dIXJNWiwDxpw13I4pTUAsNxZdg6E0mI2kTQb0P2iHczg1Tu+H4EBgJR+hYhKiHKko7qg==}
     dependencies:
-      "@codemirror/autocomplete": 6.4.2(@codemirror/language@6.6.0)(@codemirror/state@6.2.0)(@codemirror/view@6.9.3)(@lezer/common@1.0.2)
-      "@codemirror/language": 6.6.0
-      "@codemirror/state": 6.2.0
-      "@lezer/css": 1.1.1
+      '@codemirror/autocomplete': 6.15.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.1)(@lezer/common@1.2.1)
+      '@codemirror/language': 6.10.1
+      '@codemirror/state': 6.4.1
+      '@lezer/common': 1.2.1
+      '@lezer/css': 1.1.8
     transitivePeerDependencies:
-      - "@codemirror/view"
-      - "@lezer/common"
+      - '@codemirror/view'
     dev: true
 
-  /@codemirror/language@6.6.0:
-    resolution:
-      {
-        integrity: sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==,
-      }
+  /@codemirror/language@6.10.1:
+    resolution: {integrity: sha512-5GrXzrhq6k+gL5fjkAwt90nYDmjlzTIJV8THnxNFtNKWotMIlzzN+CpqxqwXOECnUdOndmSeWntVrVcv5axWRQ==}
     dependencies:
-      "@codemirror/state": 6.2.0
-      "@codemirror/view": 6.9.3
-      "@lezer/common": 1.0.2
-      "@lezer/highlight": 1.1.4
-      "@lezer/lr": 1.3.3
-      style-mod: 4.0.2
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.26.1
+      '@lezer/common': 1.2.1
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.4.0
+      style-mod: 4.1.2
     dev: true
 
-  /@codemirror/lint@6.2.0:
-    resolution:
-      {
-        integrity: sha512-KVCECmR2fFeYBr1ZXDVue7x3q5PMI0PzcIbA+zKufnkniMBo1325t0h1jM85AKp8l3tj67LRxVpZfgDxEXlQkg==,
-      }
+  /@codemirror/lint@6.5.0:
+    resolution: {integrity: sha512-+5YyicIaaAZKU8K43IQi8TBy6mF6giGeWAH7N96Z5LC30Wm5JMjqxOYIE9mxwMG1NbhT2mA3l9hA4uuKUM3E5g==}
     dependencies:
-      "@codemirror/state": 6.2.0
-      "@codemirror/view": 6.9.3
-      crelt: 1.0.5
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.26.1
+      crelt: 1.0.6
     dev: true
 
-  /@codemirror/search@6.3.0:
-    resolution:
-      {
-        integrity: sha512-rBhZxzT34CarfhgCZGhaLBScABDN3iqJxixzNuINp9lrb3lzm0nTpR77G1VrxGO3HOGK7j62jcJftQM7eCOIuw==,
-      }
+  /@codemirror/search@6.5.6:
+    resolution: {integrity: sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==}
     dependencies:
-      "@codemirror/state": 6.2.0
-      "@codemirror/view": 6.9.3
-      crelt: 1.0.5
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.26.1
+      crelt: 1.0.6
     dev: true
 
-  /@codemirror/state@6.2.0:
-    resolution:
-      {
-        integrity: sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA==,
-      }
+  /@codemirror/state@6.4.1:
+    resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
     dev: true
 
-  /@codemirror/view@6.9.3:
-    resolution:
-      {
-        integrity: sha512-BJ5mvEIhFM+SrNwc5X8pLIvMM9ffjkviVbxpg84Xk2OE8ZyKaEbId8kX+nAYEEso7+qnbwsXe1bkAHsasebMow==,
-      }
+  /@codemirror/view@6.26.1:
+    resolution: {integrity: sha512-wLw0t3R9AwOSQThdZ5Onw8QQtem5asE7+bPlnzc57eubPqiuJKIzwjMZ+C42vQett+iva+J8VgFV4RYWDBh5FA==}
     dependencies:
-      "@codemirror/state": 6.2.0
-      style-mod: 4.0.2
-      w3c-keyname: 2.2.6
+      '@codemirror/state': 6.4.1
+      style-mod: 4.1.2
+      w3c-keyname: 2.2.8
     dev: true
 
-  /@ddietr/codemirror-themes@1.4.0:
-    resolution:
-      {
-        integrity: sha512-FPEHcpK3FusL5cDxZk8rgw89Y2VR1BtUEhClsDE11VwusHONjWTctrPxj1zlRWiP8aujCV0PHUYyTqDErL1C/g==,
-      }
+  /@ddietr/codemirror-themes@1.4.2:
+    resolution: {integrity: sha512-8U3H3lmtmSWLD5VRlt7jf2HW62URnwgPxjZZDYjBX5EtMpgZ2QnqiIYrNzdQPPjJngT9D43gls3+JlekCBmrfw==}
     dependencies:
-      "@codemirror/language": 6.6.0
-      "@codemirror/state": 6.2.0
-      "@codemirror/view": 6.9.3
-      "@lezer/highlight": 1.1.4
+      '@codemirror/language': 6.10.1
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.26.1
+      '@lezer/highlight': 1.2.0
     dev: true
 
-  /@electron/asar@3.2.3:
-    resolution:
-      {
-        integrity: sha512-wmOfE6szYyqZhRIiLH+eyZEp+bGcJI0OD/SCvSUrfBE0jvauyGYO2ZhpWxmNCcDojKu5DYrsVqT5BOCZZ01XIg==,
-      }
-    engines: { node: ">=10.12.0" }
+  /@electron/asar@3.2.9:
+    resolution: {integrity: sha512-Vu2P3X2gcZ3MY9W7yH72X9+AMXwUQZEJBrsPIbX0JsdllLtoh62/Q8Wg370/DawIEVKOyfD6KtTLo645ezqxUA==}
+    engines: {node: '>=10.12.0'}
+    hasBin: true
     dependencies:
-      chromium-pickle-js: 0.2.0
       commander: 5.1.0
       glob: 7.2.3
       minimatch: 3.1.2
-    optionalDependencies:
-      "@types/glob": 7.2.0
     dev: true
 
-  /@esbuild/android-arm64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/aix-ppc64@0.19.12:
+    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.19.12:
+    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.16.17:
-    resolution:
-      {
-        integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/android-arm@0.19.12:
+    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
+    engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/android-x64@0.19.12:
+    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/darwin-arm64@0.19.12:
+    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/darwin-x64@0.19.12:
+    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/freebsd-arm64@0.19.12:
+    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/freebsd-x64@0.19.12:
+    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/linux-arm64@0.19.12:
+    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.16.17:
-    resolution:
-      {
-        integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/linux-arm@0.19.12:
+    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
+    engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.16.17:
-    resolution:
-      {
-        integrity: sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/linux-ia32@0.19.12:
+    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
+    engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/linux-loong64@0.19.12:
+    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
+    engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.16.17:
-    resolution:
-      {
-        integrity: sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/linux-mips64el@0.19.12:
+    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
+    engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/linux-ppc64@0.19.12:
+    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
+    engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/linux-riscv64@0.19.12:
+    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
+    engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.16.17:
-    resolution:
-      {
-        integrity: sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/linux-s390x@0.19.12:
+    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
+    engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/linux-x64@0.19.12:
+    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/netbsd-x64@0.19.12:
+    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/openbsd-x64@0.19.12:
+    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/sunos-x64@0.19.12:
+    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/win32-arm64@0.19.12:
+    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.16.17:
-    resolution:
-      {
-        integrity: sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/win32-ia32@0.19.12:
+    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
+    engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.16.17:
-    resolution:
-      {
-        integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==,
-      }
-    engines: { node: ">=12" }
+  /@esbuild/win32-x64@0.19.12:
+    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@jridgewell/gen-mapping@0.3.2:
-    resolution:
-      {
-        integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==,
-      }
-    engines: { node: ">=6.0.0" }
+  /@lezer/common@1.2.1:
+    resolution: {integrity: sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==}
+    dev: true
+
+  /@lezer/css@1.1.8:
+    resolution: {integrity: sha512-7JhxupKuMBaWQKjQoLtzhGj83DdnZY9MckEOG5+/iLKNK2ZJqKc6hf6uc0HjwCX7Qlok44jBNqZhHKDhEhZYLA==}
     dependencies:
-      "@jridgewell/set-array": 1.1.2
-      "@jridgewell/sourcemap-codec": 1.4.14
-      "@jridgewell/trace-mapping": 0.3.17
+      '@lezer/common': 1.2.1
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.4.0
     dev: true
 
-  /@jridgewell/resolve-uri@3.1.0:
-    resolution:
-      {
-        integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==,
-      }
-    engines: { node: ">=6.0.0" }
-    dev: true
-
-  /@jridgewell/set-array@1.1.2:
-    resolution:
-      {
-        integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==,
-      }
-    engines: { node: ">=6.0.0" }
-    dev: true
-
-  /@jridgewell/source-map@0.3.2:
-    resolution:
-      {
-        integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==,
-      }
+  /@lezer/highlight@1.2.0:
+    resolution: {integrity: sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==}
     dependencies:
-      "@jridgewell/gen-mapping": 0.3.2
-      "@jridgewell/trace-mapping": 0.3.17
+      '@lezer/common': 1.2.1
     dev: true
 
-  /@jridgewell/sourcemap-codec@1.4.14:
-    resolution:
-      {
-        integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==,
-      }
-    dev: true
-
-  /@jridgewell/trace-mapping@0.3.17:
-    resolution:
-      {
-        integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==,
-      }
+  /@lezer/lr@1.4.0:
+    resolution: {integrity: sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==}
     dependencies:
-      "@jridgewell/resolve-uri": 3.1.0
-      "@jridgewell/sourcemap-codec": 1.4.14
+      '@lezer/common': 1.2.1
     dev: true
 
-  /@lezer/common@0.15.12:
-    resolution:
-      {
-        integrity: sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==,
-      }
+  /@octokit/auth-token@4.0.0:
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
     dev: true
 
-  /@lezer/common@1.0.2:
-    resolution:
-      {
-        integrity: sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng==,
-      }
-    dev: true
-
-  /@lezer/css@1.1.1:
-    resolution:
-      {
-        integrity: sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==,
-      }
+  /@octokit/core@5.1.0:
+    resolution: {integrity: sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==}
+    engines: {node: '>= 18'}
     dependencies:
-      "@lezer/highlight": 1.1.4
-      "@lezer/lr": 1.3.3
-    dev: true
-
-  /@lezer/highlight@1.1.4:
-    resolution:
-      {
-        integrity: sha512-IECkFmw2l7sFcYXrV8iT9GeY4W0fU4CxX0WMwhmhMIVjoDdD1Hr6q3G2NqVtLg/yVe5n7i4menG3tJ2r4eCrPQ==,
-      }
-    dependencies:
-      "@lezer/common": 1.0.2
-    dev: true
-
-  /@lezer/lr@0.15.8:
-    resolution:
-      {
-        integrity: sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==,
-      }
-    dependencies:
-      "@lezer/common": 0.15.12
-    dev: true
-
-  /@lezer/lr@1.3.3:
-    resolution:
-      {
-        integrity: sha512-JPQe3mwJlzEVqy67iQiiGozhcngbO8QBgpqZM6oL1Wj/dXckrEexpBLeFkq0edtW5IqnPRFxA24BHJni8Js69w==,
-      }
-    dependencies:
-      "@lezer/common": 1.0.2
-    dev: true
-
-  /@lmdb/lmdb-darwin-arm64@2.5.2:
-    resolution:
-      {
-        integrity: sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==,
-      }
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@lmdb/lmdb-darwin-x64@2.5.2:
-    resolution:
-      {
-        integrity: sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==,
-      }
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@lmdb/lmdb-linux-arm64@2.5.2:
-    resolution:
-      {
-        integrity: sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==,
-      }
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@lmdb/lmdb-linux-arm@2.5.2:
-    resolution:
-      {
-        integrity: sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==,
-      }
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@lmdb/lmdb-linux-x64@2.5.2:
-    resolution:
-      {
-        integrity: sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==,
-      }
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@lmdb/lmdb-win32-x64@2.5.2:
-    resolution:
-      {
-        integrity: sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==,
-      }
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@mischnic/json-sourcemap@0.1.0:
-    resolution:
-      {
-        integrity: sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==,
-      }
-    engines: { node: ">=12.0.0" }
-    dependencies:
-      "@lezer/common": 0.15.12
-      "@lezer/lr": 0.15.8
-      json5: 2.2.3
-    dev: true
-
-  /@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.2:
-    resolution:
-      {
-        integrity: sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==,
-      }
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.2:
-    resolution:
-      {
-        integrity: sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==,
-      }
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.2:
-    resolution:
-      {
-        integrity: sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==,
-      }
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@msgpackr-extract/msgpackr-extract-linux-arm@3.0.2:
-    resolution:
-      {
-        integrity: sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==,
-      }
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@msgpackr-extract/msgpackr-extract-linux-x64@3.0.2:
-    resolution:
-      {
-        integrity: sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==,
-      }
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2:
-    resolution:
-      {
-        integrity: sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==,
-      }
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@octokit/auth-token@3.0.3:
-    resolution:
-      {
-        integrity: sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==,
-      }
-    engines: { node: ">= 14" }
-    dependencies:
-      "@octokit/types": 9.0.0
-    dev: true
-
-  /@octokit/core@4.2.0:
-    resolution:
-      {
-        integrity: sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==,
-      }
-    engines: { node: ">= 14" }
-    dependencies:
-      "@octokit/auth-token": 3.0.3
-      "@octokit/graphql": 5.0.5
-      "@octokit/request": 6.2.3
-      "@octokit/request-error": 3.0.3
-      "@octokit/types": 9.0.0
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.0.2
+      '@octokit/request': 8.2.0
+      '@octokit/request-error': 5.0.1
+      '@octokit/types': 12.6.0
       before-after-hook: 2.2.3
-      universal-user-agent: 6.0.0
-    transitivePeerDependencies:
-      - encoding
+      universal-user-agent: 6.0.1
     dev: true
 
-  /@octokit/endpoint@7.0.5:
-    resolution:
-      {
-        integrity: sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==,
-      }
-    engines: { node: ">= 14" }
+  /@octokit/endpoint@9.0.4:
+    resolution: {integrity: sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==}
+    engines: {node: '>= 18'}
     dependencies:
-      "@octokit/types": 9.0.0
-      is-plain-object: 5.0.0
-      universal-user-agent: 6.0.0
+      '@octokit/types': 12.6.0
+      universal-user-agent: 6.0.1
     dev: true
 
-  /@octokit/graphql@5.0.5:
-    resolution:
-      {
-        integrity: sha512-Qwfvh3xdqKtIznjX9lz2D458r7dJPP8l6r4GQkIdWQouZwHQK0mVT88uwiU2bdTU2OtT1uOlKpRciUWldpG0yQ==,
-      }
-    engines: { node: ">= 14" }
+  /@octokit/graphql@7.0.2:
+    resolution: {integrity: sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==}
+    engines: {node: '>= 18'}
     dependencies:
-      "@octokit/request": 6.2.3
-      "@octokit/types": 9.0.0
-      universal-user-agent: 6.0.0
-    transitivePeerDependencies:
-      - encoding
+      '@octokit/request': 8.2.0
+      '@octokit/types': 12.6.0
+      universal-user-agent: 6.0.1
     dev: true
 
-  /@octokit/openapi-types@16.0.0:
-    resolution:
-      {
-        integrity: sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==,
-      }
+  /@octokit/openapi-types@20.0.0:
+    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
     dev: true
 
-  /@octokit/plugin-paginate-rest@6.0.0(@octokit/core@4.2.0):
-    resolution:
-      {
-        integrity: sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==,
-      }
-    engines: { node: ">= 14" }
+  /@octokit/plugin-paginate-rest@9.2.1(@octokit/core@5.1.0):
+    resolution: {integrity: sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==}
+    engines: {node: '>= 18'}
     peerDependencies:
-      "@octokit/core": ">=4"
+      '@octokit/core': '5'
     dependencies:
-      "@octokit/core": 4.2.0
-      "@octokit/types": 9.0.0
+      '@octokit/core': 5.1.0
+      '@octokit/types': 12.6.0
     dev: true
 
-  /@octokit/plugin-request-log@1.0.4(@octokit/core@4.2.0):
-    resolution:
-      {
-        integrity: sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==,
-      }
+  /@octokit/plugin-request-log@4.0.1(@octokit/core@5.1.0):
+    resolution: {integrity: sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==}
+    engines: {node: '>= 18'}
     peerDependencies:
-      "@octokit/core": ">=3"
+      '@octokit/core': '5'
     dependencies:
-      "@octokit/core": 4.2.0
+      '@octokit/core': 5.1.0
     dev: true
 
-  /@octokit/plugin-rest-endpoint-methods@7.0.1(@octokit/core@4.2.0):
-    resolution:
-      {
-        integrity: sha512-pnCaLwZBudK5xCdrR823xHGNgqOzRnJ/mpC/76YPpNP7DybdsJtP7mdOwh+wYZxK5jqeQuhu59ogMI4NRlBUvA==,
-      }
-    engines: { node: ">= 14" }
+  /@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.1.0):
+    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
+    engines: {node: '>= 18'}
     peerDependencies:
-      "@octokit/core": ">=3"
+      '@octokit/core': '5'
     dependencies:
-      "@octokit/core": 4.2.0
-      "@octokit/types": 9.0.0
-      deprecation: 2.3.1
+      '@octokit/core': 5.1.0
+      '@octokit/types': 12.6.0
     dev: true
 
-  /@octokit/request-error@3.0.3:
-    resolution:
-      {
-        integrity: sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==,
-      }
-    engines: { node: ">= 14" }
+  /@octokit/request-error@5.0.1:
+    resolution: {integrity: sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==}
+    engines: {node: '>= 18'}
     dependencies:
-      "@octokit/types": 9.0.0
+      '@octokit/types': 12.6.0
       deprecation: 2.3.1
       once: 1.4.0
     dev: true
 
-  /@octokit/request@6.2.3:
-    resolution:
-      {
-        integrity: sha512-TNAodj5yNzrrZ/VxP+H5HiYaZep0H3GU0O7PaF+fhDrt8FPrnkei9Aal/txsN/1P7V3CPiThG0tIvpPDYUsyAA==,
-      }
-    engines: { node: ">= 14" }
+  /@octokit/request@8.2.0:
+    resolution: {integrity: sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==}
+    engines: {node: '>= 18'}
     dependencies:
-      "@octokit/endpoint": 7.0.5
-      "@octokit/request-error": 3.0.3
-      "@octokit/types": 9.0.0
-      is-plain-object: 5.0.0
-      node-fetch: 2.6.9
-      universal-user-agent: 6.0.0
-    transitivePeerDependencies:
-      - encoding
+      '@octokit/endpoint': 9.0.4
+      '@octokit/request-error': 5.0.1
+      '@octokit/types': 12.6.0
+      universal-user-agent: 6.0.1
     dev: true
 
-  /@octokit/rest@19.0.7:
-    resolution:
-      {
-        integrity: sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==,
-      }
-    engines: { node: ">= 14" }
+  /@octokit/rest@20.1.0:
+    resolution: {integrity: sha512-STVO3itHQLrp80lvcYB2UIKoeil5Ctsgd2s1AM+du3HqZIR35ZH7WE9HLwUOLXH0myA0y3AGNPo8gZtcgIbw0g==}
+    engines: {node: '>= 18'}
     dependencies:
-      "@octokit/core": 4.2.0
-      "@octokit/plugin-paginate-rest": 6.0.0(@octokit/core@4.2.0)
-      "@octokit/plugin-request-log": 1.0.4(@octokit/core@4.2.0)
-      "@octokit/plugin-rest-endpoint-methods": 7.0.1(@octokit/core@4.2.0)
-    transitivePeerDependencies:
-      - encoding
+      '@octokit/core': 5.1.0
+      '@octokit/plugin-paginate-rest': 9.2.1(@octokit/core@5.1.0)
+      '@octokit/plugin-request-log': 4.0.1(@octokit/core@5.1.0)
+      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.1.0)
     dev: true
 
-  /@octokit/types@9.0.0:
-    resolution:
-      {
-        integrity: sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==,
-      }
+  /@octokit/types@12.6.0:
+    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
     dependencies:
-      "@octokit/openapi-types": 16.0.0
+      '@octokit/openapi-types': 20.0.0
     dev: true
 
-  /@parcel/bundler-default@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-yJvRsNWWu5fVydsWk3O2L4yIy3UZiKWO2cPDukGOIWMgp/Vbpp+2Ct5IygVRtE22bnseW/E/oe0PV3d2IkEJGg==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/graph": 2.8.3
-      "@parcel/hash": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/cache@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-k7xv5vSQrJLdXuglo+Hv3yF4BCSs1tQ/8Vbd6CHTkOhf7LcGg6CPtLw053R/KdMpd/4GPn0QrAsOLdATm1ELtQ==,
-      }
-    engines: { node: ">= 12.0.0" }
-    peerDependencies:
-      "@parcel/core": ^2.8.3
-    dependencies:
-      "@parcel/core": 2.8.3
-      "@parcel/fs": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/logger": 2.8.3
-      "@parcel/utils": 2.8.3
-      lmdb: 2.5.2
-    dev: true
-
-  /@parcel/codeframe@2.8.3:
-    resolution:
-      {
-        integrity: sha512-FE7sY53D6n/+2Pgg6M9iuEC6F5fvmyBkRE4d9VdnOoxhTXtkEqpqYgX7RJ12FAQwNlxKq4suBJQMgQHMF2Kjeg==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      chalk: 4.1.2
-    dev: true
-
-  /@parcel/compressor-raw@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-bVDsqleBUxRdKMakWSlWC9ZjOcqDKE60BE+Gh3JSN6WJrycJ02P5wxjTVF4CStNP/G7X17U+nkENxSlMG77ySg==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/config-default@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-o/A/mbrO6X/BfGS65Sib8d6SSG45NYrNooNBkH/o7zbOBSRQxwyTlysleK1/3Wa35YpvFyLOwgfakqCtbGy4fw==,
-      }
-    peerDependencies:
-      "@parcel/core": ^2.8.3
-    dependencies:
-      "@parcel/bundler-default": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/compressor-raw": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/core": 2.8.3
-      "@parcel/namer-default": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/optimizer-css": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/optimizer-htmlnano": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/optimizer-image": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/optimizer-svgo": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/optimizer-terser": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/packager-css": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/packager-html": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/packager-js": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/packager-raw": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/packager-svg": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/reporter-dev-server": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/resolver-default": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/runtime-browser-hmr": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/runtime-js": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/runtime-react-refresh": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/runtime-service-worker": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-babel": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-css": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-html": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-image": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-js": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-json": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-postcss": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-posthtml": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-raw": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-react-refresh-wrap": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/transformer-svg": 2.8.3(@parcel/core@2.8.3)
-    transitivePeerDependencies:
-      - cssnano
-      - postcss
-      - purgecss
-      - relateurl
-      - srcset
-      - terser
-      - uncss
-    dev: true
-
-  /@parcel/core@2.8.3:
-    resolution:
-      {
-        integrity: sha512-Euf/un4ZAiClnlUXqPB9phQlKbveU+2CotZv7m7i+qkgvFn5nAGnrV4h1OzQU42j9dpgOxWi7AttUDMrvkbhCQ==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      "@mischnic/json-sourcemap": 0.1.0
-      "@parcel/cache": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/events": 2.8.3
-      "@parcel/fs": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/graph": 2.8.3
-      "@parcel/hash": 2.8.3
-      "@parcel/logger": 2.8.3
-      "@parcel/package-manager": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/source-map": 2.1.1
-      "@parcel/types": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      "@parcel/workers": 2.8.3(@parcel/core@2.8.3)
-      abortcontroller-polyfill: 1.7.5
-      base-x: 3.0.9
-      browserslist: 4.21.5
-      clone: 2.1.2
-      dotenv: 7.0.0
-      dotenv-expand: 5.1.0
-      json5: 2.2.3
-      msgpackr: 1.8.5
-      nullthrows: 1.1.1
-      semver: 5.7.1
-    dev: true
-
-  /@parcel/diagnostic@2.8.3:
-    resolution:
-      {
-        integrity: sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      "@mischnic/json-sourcemap": 0.1.0
-      nullthrows: 1.1.1
-    dev: true
-
-  /@parcel/events@2.8.3:
-    resolution:
-      {
-        integrity: sha512-hoIS4tAxWp8FJk3628bsgKxEvR7bq2scCVYHSqZ4fTi/s0+VymEATrRCUqf+12e5H47uw1/ZjoqrGtBI02pz4w==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dev: true
-
-  /@parcel/fs-search@2.8.3:
-    resolution:
-      {
-        integrity: sha512-DJBT2N8knfN7Na6PP2mett3spQLTqxFrvl0gv+TJRp61T8Ljc4VuUTb0hqBj+belaASIp3Q+e8+SgaFQu7wLiQ==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      detect-libc: 1.0.3
-    dev: true
-
-  /@parcel/fs@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==,
-      }
-    engines: { node: ">= 12.0.0" }
-    peerDependencies:
-      "@parcel/core": ^2.8.3
-    dependencies:
-      "@parcel/core": 2.8.3
-      "@parcel/fs-search": 2.8.3
-      "@parcel/types": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      "@parcel/watcher": 2.1.0
-      "@parcel/workers": 2.8.3(@parcel/core@2.8.3)
-    dev: true
-
-  /@parcel/graph@2.8.3:
-    resolution:
-      {
-        integrity: sha512-26GL8fYZPdsRhSXCZ0ZWliloK6DHlMJPWh6Z+3VVZ5mnDSbYg/rRKWmrkhnr99ZWmL9rJsv4G74ZwvDEXTMPBg==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      nullthrows: 1.1.1
-    dev: true
-
-  /@parcel/hash@2.8.3:
-    resolution:
-      {
-        integrity: sha512-FVItqzjWmnyP4ZsVgX+G00+6U2IzOvqDtdwQIWisCcVoXJFCqZJDy6oa2qDDFz96xCCCynjRjPdQx2jYBCpfYw==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      detect-libc: 1.0.3
-      xxhash-wasm: 0.4.2
-    dev: true
-
-  /@parcel/logger@2.8.3:
-    resolution:
-      {
-        integrity: sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/events": 2.8.3
-    dev: true
-
-  /@parcel/markdown-ansi@2.8.3:
-    resolution:
-      {
-        integrity: sha512-4v+pjyoh9f5zuU/gJlNvNFGEAb6J90sOBwpKJYJhdWXLZMNFCVzSigxrYO+vCsi8G4rl6/B2c0LcwIMjGPHmFQ==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      chalk: 4.1.2
-    dev: true
-
-  /@parcel/namer-default@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-tJ7JehZviS5QwnxbARd8Uh63rkikZdZs1QOyivUhEvhN+DddSAVEdQLHGPzkl3YRk0tjFhbqo+Jci7TpezuAMw==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/node-resolver-core@2.8.3:
-    resolution:
-      {
-        integrity: sha512-12YryWcA5Iw2WNoEVr/t2HDjYR1iEzbjEcxfh1vaVDdZ020PiGw67g5hyIE/tsnG7SRJ0xdRx1fQ2hDgED+0Ww==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/utils": 2.8.3
-      nullthrows: 1.1.1
-      semver: 5.7.1
-    dev: true
-
-  /@parcel/optimizer-css@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-JotGAWo8JhuXsQDK0UkzeQB0UR5hDAKvAviXrjqB4KM9wZNLhLleeEAW4Hk8R9smCeQFP6Xg/N/NkLDpqMwT3g==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/source-map": 2.1.1
-      "@parcel/utils": 2.8.3
-      browserslist: 4.21.5
-      lightningcss: 1.19.0
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/optimizer-htmlnano@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-L8/fHbEy8Id2a2E0fwR5eKGlv9VYDjrH9PwdJE9Za9v1O/vEsfl/0T/79/x129l5O0yB6EFQkFa20MiK3b+vOg==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      htmlnano: 2.0.3(svgo@2.8.0)
-      nullthrows: 1.1.1
-      posthtml: 0.16.6
-      svgo: 2.8.0
-    transitivePeerDependencies:
-      - "@parcel/core"
-      - cssnano
-      - postcss
-      - purgecss
-      - relateurl
-      - srcset
-      - terser
-      - uncss
-    dev: true
-
-  /@parcel/optimizer-image@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-SD71sSH27SkCDNUNx9A3jizqB/WIJr3dsfp+JZGZC42tpD/Siim6Rqy9M4To/BpMMQIIiEXa5ofwS+DgTEiEHQ==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      "@parcel/workers": 2.8.3(@parcel/core@2.8.3)
-      detect-libc: 1.0.3
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/optimizer-svgo@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-9KQed99NZnQw3/W4qBYVQ7212rzA9EqrQG019TIWJzkA9tjGBMIm2c/nXpK1tc3hQ3e7KkXkFCQ3C+ibVUnHNA==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      svgo: 2.8.0
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/optimizer-terser@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-9EeQlN6zIeUWwzrzu6Q2pQSaYsYGah8MtiQ/hog9KEPlYTP60hBv/+utDyYEHSQhL7y5ym08tPX5GzBvwAD/dA==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/source-map": 2.1.1
-      "@parcel/utils": 2.8.3
-      nullthrows: 1.1.1
-      terser: 5.16.8
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/package-manager@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-tIpY5pD2lH53p9hpi++GsODy6V3khSTX4pLEGuMpeSYbHthnOViobqIlFLsjni+QA1pfc8NNNIQwSNdGjYflVA==,
-      }
-    engines: { node: ">= 12.0.0" }
-    peerDependencies:
-      "@parcel/core": ^2.8.3
-    dependencies:
-      "@parcel/core": 2.8.3
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/fs": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/logger": 2.8.3
-      "@parcel/types": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      "@parcel/workers": 2.8.3(@parcel/core@2.8.3)
-      semver: 5.7.1
-    dev: true
-
-  /@parcel/packager-css@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-WyvkMmsurlHG8d8oUVm7S+D+cC/T3qGeqogb7sTI52gB6uiywU7lRCizLNqGFyFGIxcVTVHWnSHqItBcLN76lA==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/source-map": 2.1.1
-      "@parcel/utils": 2.8.3
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/packager-html@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-OhPu1Hx1RRKJodpiu86ZqL8el2Aa4uhBHF6RAL1Pcrh2EhRRlPf70Sk0tC22zUpYL7es+iNKZ/n0Rl+OWSHWEw==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/types": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      nullthrows: 1.1.1
-      posthtml: 0.16.6
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/packager-js@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-0pGKC3Ax5vFuxuZCRB+nBucRfFRz4ioie19BbDxYnvBxrd4M3FIu45njf6zbBYsI9eXqaDnL1b3DcZJfYqtIzw==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/hash": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/source-map": 2.1.1
-      "@parcel/utils": 2.8.3
-      globals: 13.20.0
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/packager-raw@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-BA6enNQo1RCnco9MhkxGrjOk59O71IZ9DPKu3lCtqqYEVd823tXff2clDKHK25i6cChmeHu6oB1Rb73hlPqhUA==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/packager-svg@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-mvIoHpmv5yzl36OjrklTDFShLUfPFTwrmp1eIwiszGdEBuQaX7JVI3Oo2jbVQgcN4W7J6SENzGQ3Q5hPTW3pMw==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/types": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      posthtml: 0.16.6
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/plugin@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-jZ6mnsS4D9X9GaNnvrixDQwlUQJCohDX2hGyM0U0bY2NWU8Km97SjtoCpWjq+XBCx/gpC4g58+fk9VQeZq2vlw==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      "@parcel/types": 2.8.3(@parcel/core@2.8.3)
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/reporter-dev-server@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-Y8C8hzgzTd13IoWTj+COYXEyCkXfmVJs3//GDBsH22pbtSFMuzAZd+8J9qsCo0EWpiDow7V9f1LischvEh3FbQ==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/resolver-default@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-k0B5M/PJ+3rFbNj4xZSBr6d6HVIe6DH/P3dClLcgBYSXAvElNDfXgtIimbjCyItFkW9/BfcgOVKEEIZOeySH/A==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/node-resolver-core": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/runtime-browser-hmr@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-2O1PYi2j/Q0lTyGNV3JdBYwg4rKo6TEVFlYGdd5wCYU9ZIN9RRuoCnWWH2qCPj3pjIVtBeppYxzfVjPEHINWVg==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/runtime-js@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-IRja0vNKwvMtPgIqkBQh0QtRn0XcxNC8HU1jrgWGRckzu10qJWO+5ULgtOeR4pv9krffmMPqywGXw6l/gvJKYQ==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/runtime-react-refresh@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-2v/qFKp00MfG0234OdOgQNAo6TLENpFYZMbVbAsPMY9ITiqG73MrEsrGXVoGbYiGTMB/Toer/lSWlJxtacOCuA==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      react-error-overlay: 6.0.9
-      react-refresh: 0.9.0
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/runtime-service-worker@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-/Skkw+EeRiwzOJso5fQtK8c9b452uWLNhQH1ISTodbmlcyB4YalAiSsyHCtMYD0c3/t5Sx4ZS7vxBAtQd0RvOw==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/source-map@2.1.1:
-    resolution:
-      {
-        integrity: sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==,
-      }
-    engines: { node: ^12.18.3 || >=14 }
-    dependencies:
-      detect-libc: 1.0.3
-    dev: true
-
-  /@parcel/transformer-babel@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-L6lExfpvvC7T/g3pxf3CIJRouQl+sgrSzuWQ0fD4PemUDHvHchSP4SNUVnd6gOytF3Y1KpnEZIunQGi5xVqQCQ==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/source-map": 2.1.1
-      "@parcel/utils": 2.8.3
-      browserslist: 4.21.5
-      json5: 2.2.3
-      nullthrows: 1.1.1
-      semver: 5.7.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/transformer-css@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-xTqFwlSXtnaYen9ivAgz+xPW7yRl/u4QxtnDyDpz5dr8gSeOpQYRcjkd4RsYzKsWzZcGtB5EofEk8ayUbWKEUg==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/source-map": 2.1.1
-      "@parcel/utils": 2.8.3
-      browserslist: 4.21.5
-      lightningcss: 1.19.0
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/transformer-html@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-kIZO3qsMYTbSnSpl9cnZog+SwL517ffWH54JeB410OSAYF1ouf4n5v9qBnALZbuCCmPwJRGs4jUtE452hxwN4g==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/hash": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      nullthrows: 1.1.1
-      posthtml: 0.16.6
-      posthtml-parser: 0.10.2
-      posthtml-render: 3.0.0
-      semver: 5.7.1
-      srcset: 4.0.0
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/transformer-image@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-cO4uptcCGTi5H6bvTrAWEFUsTNhA4kCo8BSvRSCHA2sf/4C5tGQPHt3JhdO0GQLPwZRCh/R41EkJs5HZ8A8DAg==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    peerDependencies:
-      "@parcel/core": ^2.8.3
-    dependencies:
-      "@parcel/core": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      "@parcel/workers": 2.8.3(@parcel/core@2.8.3)
-      nullthrows: 1.1.1
-    dev: true
-
-  /@parcel/transformer-js@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-9Qd6bib+sWRcpovvzvxwy/PdFrLUXGfmSW9XcVVG8pvgXsZPFaNjnNT8stzGQj1pQiougCoxMY4aTM5p1lGHEQ==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    peerDependencies:
-      "@parcel/core": ^2.8.3
-    dependencies:
-      "@parcel/core": 2.8.3
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/source-map": 2.1.1
-      "@parcel/utils": 2.8.3
-      "@parcel/workers": 2.8.3(@parcel/core@2.8.3)
-      "@swc/helpers": 0.4.14
-      browserslist: 4.21.5
-      detect-libc: 1.0.3
-      nullthrows: 1.1.1
-      regenerator-runtime: 0.13.11
-      semver: 5.7.1
-    dev: true
-
-  /@parcel/transformer-json@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-B7LmVq5Q7bZO4ERb6NHtRuUKWGysEeaj9H4zelnyBv+wLgpo4f5FCxSE1/rTNmP9u1qHvQ3scGdK6EdSSokGPg==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      json5: 2.2.3
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/transformer-postcss@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-e8luB/poIlz6jBsD1Izms+6ElbyzuoFVa4lFVLZnTAChI3UxPdt9p/uTsIO46HyBps/Bk8ocvt3J4YF84jzmvg==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/hash": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      clone: 2.1.2
-      nullthrows: 1.1.1
-      postcss-value-parser: 4.2.0
-      semver: 5.7.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/transformer-posthtml@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-pkzf9Smyeaw4uaRLsT41RGrPLT5Aip8ZPcntawAfIo+KivBQUV0erY1IvHYjyfFzq1ld/Fo2Ith9He6mxpPifA==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      nullthrows: 1.1.1
-      posthtml: 0.16.6
-      posthtml-parser: 0.10.2
-      posthtml-render: 3.0.0
-      semver: 5.7.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/transformer-raw@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-G+5cXnd2/1O3nV/pgRxVKZY/HcGSseuhAe71gQdSQftb8uJEURyUHoQ9Eh0JUD3MgWh9V+nIKoyFEZdf9T0sUQ==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/transformer-react-refresh-wrap@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-q8AAoEvBnCf/nPvgOwFwKZfEl/thwq7c2duxXkhl+tTLDRN2vGmyz4355IxCkavSX+pLWSQ5MexklSEeMkgthg==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      react-refresh: 0.9.0
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/transformer-sass@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-ak196rjvXdsBOGi5aTkBEKv6i4LKQgOkHuaKEjeT8g2a3CU6Z36J+j2GbZzsznfws/hH+CRTf8bAsbkxtKlkjQ==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/source-map": 2.1.1
-      sass: 1.60.0
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/transformer-svg@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-3Zr/gBzxi1ZH1fftH/+KsZU7w5GqkmxlB0ZM8ovS5E/Pl1lq1t0xvGJue9m2VuQqP8Mxfpl5qLFmsKlhaZdMIQ==,
-      }
-    engines: { node: ">= 12.0.0", parcel: ^2.8.3 }
-    dependencies:
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/hash": 2.8.3
-      "@parcel/plugin": 2.8.3(@parcel/core@2.8.3)
-      nullthrows: 1.1.1
-      posthtml: 0.16.6
-      posthtml-parser: 0.10.2
-      posthtml-render: 3.0.0
-      semver: 5.7.1
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/types@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==,
-      }
-    dependencies:
-      "@parcel/cache": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/fs": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/package-manager": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/source-map": 2.1.1
-      "@parcel/workers": 2.8.3(@parcel/core@2.8.3)
-      utility-types: 3.10.0
-    transitivePeerDependencies:
-      - "@parcel/core"
-    dev: true
-
-  /@parcel/utils@2.8.3:
-    resolution:
-      {
-        integrity: sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      "@parcel/codeframe": 2.8.3
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/hash": 2.8.3
-      "@parcel/logger": 2.8.3
-      "@parcel/markdown-ansi": 2.8.3
-      "@parcel/source-map": 2.1.1
-      chalk: 4.1.2
-    dev: true
-
-  /@parcel/watcher@2.1.0:
-    resolution:
-      {
-        integrity: sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==,
-      }
-    engines: { node: ">= 10.0.0" }
-    requiresBuild: true
-    dependencies:
-      is-glob: 4.0.3
-      micromatch: 4.0.5
-      node-addon-api: 3.2.1
-      node-gyp-build: 4.6.0
-    dev: true
-
-  /@parcel/workers@2.8.3(@parcel/core@2.8.3):
-    resolution:
-      {
-        integrity: sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==,
-      }
-    engines: { node: ">= 12.0.0" }
-    peerDependencies:
-      "@parcel/core": ^2.8.3
-    dependencies:
-      "@parcel/core": 2.8.3
-      "@parcel/diagnostic": 2.8.3
-      "@parcel/logger": 2.8.3
-      "@parcel/types": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/utils": 2.8.3
-      chrome-trace-event: 1.0.3
-      nullthrows: 1.1.1
-    dev: true
-
-  /@pnpm/config.env-replace@1.0.0:
-    resolution:
-      {
-        integrity: sha512-ZVPVDi1E8oeXlYqkGRtX0CkzLTwE2zt62bjWaWKaAvI8NZqHzlMvGeSNDpW+JB3+aKanYb4UETJOF1/CxGPemA==,
-      }
-    engines: { node: ">=12.22.0" }
+  /@pnpm/config.env-replace@1.1.0:
+    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
+    engines: {node: '>=12.22.0'}
     dev: true
 
   /@pnpm/network.ca-file@1.0.2:
-    resolution:
-      {
-        integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==,
-      }
-    engines: { node: ">=12.22.0" }
+    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
+    engines: {node: '>=12.22.0'}
     dependencies:
       graceful-fs: 4.2.10
     dev: true
 
-  /@pnpm/npm-conf@2.1.0:
-    resolution:
-      {
-        integrity: sha512-Oe6ntvgsMTE3hDIqy6sajqHF+MnzJrOF06qC2QSiUEybLL7cp6tjoKUa32gpd9+KPVl4QyMs3E3nsXrx/Vdnlw==,
-      }
-    engines: { node: ">=12" }
+  /@pnpm/npm-conf@2.2.2:
+    resolution: {integrity: sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==}
+    engines: {node: '>=12'}
     dependencies:
-      "@pnpm/config.env-replace": 1.0.0
-      "@pnpm/network.ca-file": 1.0.2
+      '@pnpm/config.env-replace': 1.1.0
+      '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
     dev: true
 
-  /@sindresorhus/is@5.3.0:
-    resolution:
-      {
-        integrity: sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==,
-      }
-    engines: { node: ">=14.16" }
-    dev: true
-
-  /@swc/helpers@0.4.14:
-    resolution:
-      {
-        integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==,
-      }
-    dependencies:
-      tslib: 2.5.0
+  /@sindresorhus/is@5.6.0:
+    resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
+    engines: {node: '>=14.16'}
     dev: true
 
   /@szmarczak/http-timer@5.0.1:
-    resolution:
-      {
-        integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==,
-      }
-    engines: { node: ">=14.16" }
+    resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
+    engines: {node: '>=14.16'}
     dependencies:
       defer-to-connect: 2.0.1
     dev: true
 
-  /@trysound/sax@0.2.0:
-    resolution:
-      {
-        integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==,
-      }
-    engines: { node: ">=10.13.0" }
+  /@types/http-cache-semantics@4.0.4:
+    resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
     dev: true
 
-  /@types/glob@7.2.0:
-    resolution:
-      {
-        integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==,
-      }
-    requiresBuild: true
+  /@types/node@18.19.29:
+    resolution: {integrity: sha512-5pAX7ggTmWZdhUrhRWLPf+5oM7F80bcKVCBbr0zwEkTNzTJL2CWQjznpFgHYy6GrzkYi2Yjy7DHKoynFxqPV8g==}
     dependencies:
-      "@types/minimatch": 5.1.2
-      "@types/node": 18.15.11
-    dev: true
-    optional: true
-
-  /@types/http-cache-semantics@4.0.1:
-    resolution:
-      {
-        integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==,
-      }
+      undici-types: 5.26.5
     dev: true
 
-  /@types/minimatch@5.1.2:
-    resolution:
-      {
-        integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==,
-      }
-    dev: true
-    optional: true
-
-  /@types/node@18.15.11:
-    resolution:
-      {
-        integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==,
-      }
-    dev: true
-
-  /@types/parse-json@4.0.0:
-    resolution:
-      {
-        integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==,
-      }
-    dev: true
-
-  /abortcontroller-polyfill@1.7.5:
-    resolution:
-      {
-        integrity: sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==,
-      }
-    dev: true
-
-  /acorn@8.8.2:
-    resolution:
-      {
-        integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==,
-      }
-    engines: { node: ">=0.4.0" }
+  /adm-zip@0.5.12:
+    resolution: {integrity: sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ==}
+    engines: {node: '>=6.0'}
     dev: true
 
   /ansi-align@3.0.1:
-    resolution:
-      {
-        integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==,
-      }
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
     dependencies:
       string-width: 4.2.3
     dev: true
 
   /ansi-regex@5.0.1:
-    resolution:
-      {
-        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
     dev: true
 
   /ansi-regex@6.0.1:
-    resolution:
-      {
-        integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==,
-      }
-    engines: { node: ">=12" }
-    dev: true
-
-  /ansi-styles@3.2.1:
-    resolution:
-      {
-        integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==,
-      }
-    engines: { node: ">=4" }
-    dependencies:
-      color-convert: 1.9.3
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+    engines: {node: '>=12'}
     dev: true
 
   /ansi-styles@4.3.0:
-    resolution:
-      {
-        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
     dev: true
 
   /ansi-styles@6.2.1:
-    resolution:
-      {
-        integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
     dev: true
 
   /anymatch@3.1.3:
-    resolution:
-      {
-        integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
     dev: true
 
   /balanced-match@1.0.2:
-    resolution:
-      {
-        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
-      }
-    dev: true
-
-  /base-x@3.0.9:
-    resolution:
-      {
-        integrity: sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==,
-      }
-    dependencies:
-      safe-buffer: 5.2.1
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
   /before-after-hook@2.2.3:
-    resolution:
-      {
-        integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==,
-      }
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
     dev: true
 
-  /binary-extensions@2.2.0:
-    resolution:
-      {
-        integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==,
-      }
-    engines: { node: ">=8" }
+  /binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
     dev: true
 
-  /boolbase@1.0.0:
-    resolution:
-      {
-        integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
-      }
-    dev: true
-
-  /boxen@7.0.2:
-    resolution:
-      {
-        integrity: sha512-1Z4UJabXUP1/R9rLpoU3O2lEMnG3pPLAs/ZD2lF3t2q7qD5lM8rqbtnvtvm4N0wEyNlE+9yZVTVAGmd1V5jabg==,
-      }
-    engines: { node: ">=14.16" }
+  /boxen@7.1.1:
+    resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
+    engines: {node: '>=14.16'}
     dependencies:
       ansi-align: 3.0.1
       camelcase: 7.0.1
-      chalk: 5.2.0
+      chalk: 5.3.0
       cli-boxes: 3.0.0
       string-width: 5.1.2
       type-fest: 2.19.0
@@ -1890,129 +553,50 @@ packages:
     dev: true
 
   /brace-expansion@1.1.11:
-    resolution:
-      {
-        integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==,
-      }
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
     dev: true
 
   /braces@3.0.2:
-    resolution:
-      {
-        integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
     dev: true
 
-  /browserslist@4.21.5:
-    resolution:
-      {
-        integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==,
-      }
-    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
-    dependencies:
-      caniuse-lite: 1.0.30001473
-      electron-to-chromium: 1.4.348
-      node-releases: 2.0.10
-      update-browserslist-db: 1.0.10(browserslist@4.21.5)
-    dev: true
-
-  /buffer-from@1.1.2:
-    resolution:
-      {
-        integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
-      }
-    dev: true
-
   /cacheable-lookup@7.0.0:
-    resolution:
-      {
-        integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==,
-      }
-    engines: { node: ">=14.16" }
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
     dev: true
 
-  /cacheable-request@10.2.9:
-    resolution:
-      {
-        integrity: sha512-CaAMr53AS1Tb9evO1BIWFnZjSr8A4pbXofpsNVWPMDZZj3ZQKHwsQG9BrTqQ4x5ZYJXz1T2b8LLtTZODxSpzbg==,
-      }
-    engines: { node: ">=14.16" }
+  /cacheable-request@10.2.14:
+    resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
+    engines: {node: '>=14.16'}
     dependencies:
-      "@types/http-cache-semantics": 4.0.1
+      '@types/http-cache-semantics': 4.0.4
       get-stream: 6.0.1
       http-cache-semantics: 4.1.1
-      keyv: 4.5.2
+      keyv: 4.5.4
       mimic-response: 4.0.0
-      normalize-url: 8.0.0
+      normalize-url: 8.0.1
       responselike: 3.0.0
     dev: true
 
-  /callsites@3.1.0:
-    resolution:
-      {
-        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
-      }
-    engines: { node: ">=6" }
-    dev: true
-
   /camelcase@7.0.1:
-    resolution:
-      {
-        integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==,
-      }
-    engines: { node: ">=14.16" }
+    resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
+    engines: {node: '>=14.16'}
     dev: true
 
-  /caniuse-lite@1.0.30001473:
-    resolution:
-      {
-        integrity: sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==,
-      }
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
-  /chalk@2.4.2:
-    resolution:
-      {
-        integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==,
-      }
-    engines: { node: ">=4" }
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
-    dev: true
-
-  /chalk@4.1.2:
-    resolution:
-      {
-        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
-      }
-    engines: { node: ">=10" }
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-    dev: true
-
-  /chalk@5.2.0:
-    resolution:
-      {
-        integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==,
-      }
-    engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
-    dev: true
-
-  /chokidar@3.5.3:
-    resolution:
-      {
-        integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==,
-      }
-    engines: { node: ">= 8.10.0" }
+  /chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.3
       braces: 3.0.2
@@ -2022,156 +606,72 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
-  /chrome-trace-event@1.0.3:
-    resolution:
-      {
-        integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==,
-      }
-    engines: { node: ">=6.0" }
-    dev: true
-
-  /chromium-pickle-js@0.2.0:
-    resolution:
-      {
-        integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==,
-      }
-    dev: true
-
-  /ci-info@3.8.0:
-    resolution:
-      {
-        integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==,
-      }
-    engines: { node: ">=8" }
+  /ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
     dev: true
 
   /cli-boxes@3.0.0:
-    resolution:
-      {
-        integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
     dev: true
 
   /cliui@8.0.1:
-    resolution:
-      {
-        integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
     dev: true
 
-  /clone@2.1.2:
-    resolution:
-      {
-        integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==,
-      }
-    engines: { node: ">=0.8" }
-    dev: true
-
-  /codemirror@6.0.1(@lezer/common@1.0.2):
-    resolution:
-      {
-        integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==,
-      }
+  /codemirror@6.0.1(@lezer/common@1.2.1):
+    resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      "@codemirror/autocomplete": 6.4.2(@codemirror/language@6.6.0)(@codemirror/state@6.2.0)(@codemirror/view@6.9.3)(@lezer/common@1.0.2)
-      "@codemirror/commands": 6.2.2
-      "@codemirror/language": 6.6.0
-      "@codemirror/lint": 6.2.0
-      "@codemirror/search": 6.3.0
-      "@codemirror/state": 6.2.0
-      "@codemirror/view": 6.9.3
+      '@codemirror/autocomplete': 6.15.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.1)(@lezer/common@1.2.1)
+      '@codemirror/commands': 6.3.3
+      '@codemirror/language': 6.10.1
+      '@codemirror/lint': 6.5.0
+      '@codemirror/search': 6.5.6
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.26.1
     transitivePeerDependencies:
-      - "@lezer/common"
-    dev: true
-
-  /color-convert@1.9.3:
-    resolution:
-      {
-        integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==,
-      }
-    dependencies:
-      color-name: 1.1.3
+      - '@lezer/common'
     dev: true
 
   /color-convert@2.0.1:
-    resolution:
-      {
-        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
-      }
-    engines: { node: ">=7.0.0" }
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
     dev: true
 
-  /color-name@1.1.3:
-    resolution:
-      {
-        integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==,
-      }
-    dev: true
-
   /color-name@1.1.4:
-    resolution:
-      {
-        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
-      }
-    dev: true
-
-  /commander@2.20.3:
-    resolution:
-      {
-        integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
-      }
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
   /commander@5.1.0:
-    resolution:
-      {
-        integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==,
-      }
-    engines: { node: ">= 6" }
-    dev: true
-
-  /commander@7.2.0:
-    resolution:
-      {
-        integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==,
-      }
-    engines: { node: ">= 10" }
+    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+    engines: {node: '>= 6'}
     dev: true
 
   /concat-map@0.0.1:
-    resolution:
-      {
-        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
-      }
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
   /config-chain@1.1.13:
-    resolution:
-      {
-        integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==,
-      }
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
     dependencies:
       ini: 1.3.8
       proto-list: 1.2.4
     dev: true
 
   /configstore@6.0.0:
-    resolution:
-      {
-        integrity: sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==}
+    engines: {node: '>=12'}
     dependencies:
       dot-prop: 6.0.1
       graceful-fs: 4.2.11
@@ -2180,388 +680,186 @@ packages:
       xdg-basedir: 5.1.0
     dev: true
 
-  /cosmiconfig@7.1.0:
-    resolution:
-      {
-        integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==,
-      }
-    engines: { node: ">=10" }
-    dependencies:
-      "@types/parse-json": 4.0.0
-      import-fresh: 3.3.0
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      yaml: 1.10.2
-    dev: true
-
-  /crelt@1.0.5:
-    resolution:
-      {
-        integrity: sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==,
-      }
+  /crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
     dev: true
 
   /crypto-random-string@4.0.0:
-    resolution:
-      {
-        integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
+    engines: {node: '>=12'}
     dependencies:
       type-fest: 1.4.0
     dev: true
 
-  /css-select@4.3.0:
-    resolution:
-      {
-        integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==,
-      }
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.1.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
-      nth-check: 2.1.1
-    dev: true
-
-  /css-tree@1.1.3:
-    resolution:
-      {
-        integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==,
-      }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      mdn-data: 2.0.14
-      source-map: 0.6.1
-    dev: true
-
-  /css-what@6.1.0:
-    resolution:
-      {
-        integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==,
-      }
-    engines: { node: ">= 6" }
-    dev: true
-
-  /csso@4.2.0:
-    resolution:
-      {
-        integrity: sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==,
-      }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      css-tree: 1.1.3
-    dev: true
-
   /data-uri-to-buffer@4.0.1:
-    resolution:
-      {
-        integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==,
-      }
-    engines: { node: ">= 12" }
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
     dev: true
 
   /decompress-response@6.0.0:
-    resolution:
-      {
-        integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
     dependencies:
       mimic-response: 3.1.0
     dev: true
 
   /deep-extend@0.6.0:
-    resolution:
-      {
-        integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==,
-      }
-    engines: { node: ">=4.0.0" }
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
     dev: true
 
   /defer-to-connect@2.0.1:
-    resolution:
-      {
-        integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
     dev: true
 
   /deprecation@2.3.1:
-    resolution:
-      {
-        integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==,
-      }
-    dev: true
-
-  /detect-libc@1.0.3:
-    resolution:
-      {
-        integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==,
-      }
-    engines: { node: ">=0.10" }
-    dev: true
-
-  /dom-serializer@1.4.1:
-    resolution:
-      {
-        integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==,
-      }
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 4.3.1
-      entities: 2.2.0
-    dev: true
-
-  /domelementtype@2.3.0:
-    resolution:
-      {
-        integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==,
-      }
-    dev: true
-
-  /domhandler@4.3.1:
-    resolution:
-      {
-        integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==,
-      }
-    engines: { node: ">= 4" }
-    dependencies:
-      domelementtype: 2.3.0
-    dev: true
-
-  /domutils@2.8.0:
-    resolution:
-      {
-        integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==,
-      }
-    dependencies:
-      dom-serializer: 1.4.1
-      domelementtype: 2.3.0
-      domhandler: 4.3.1
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
     dev: true
 
   /dot-prop@6.0.1:
-    resolution:
-      {
-        integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
+    engines: {node: '>=10'}
     dependencies:
       is-obj: 2.0.0
     dev: true
 
-  /dotenv-expand@5.1.0:
-    resolution:
-      {
-        integrity: sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==,
-      }
-    dev: true
-
-  /dotenv@7.0.0:
-    resolution:
-      {
-        integrity: sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==,
-      }
-    engines: { node: ">=6" }
-    dev: true
-
   /eastasianwidth@0.2.0:
-    resolution:
-      {
-        integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
-      }
-    dev: true
-
-  /electron-to-chromium@1.4.348:
-    resolution:
-      {
-        integrity: sha512-gM7TdwuG3amns/1rlgxMbeeyNoBFPa+4Uu0c7FeROWh4qWmvSOnvcslKmWy51ggLKZ2n/F/4i2HJ+PVNxH9uCQ==,
-      }
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
   /emoji-regex@8.0.0:
-    resolution:
-      {
-        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
-      }
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: true
 
   /emoji-regex@9.2.2:
-    resolution:
-      {
-        integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
-      }
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
 
-  /entities@2.2.0:
-    resolution:
-      {
-        integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==,
-      }
-    dev: true
-
-  /entities@3.0.1:
-    resolution:
-      {
-        integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==,
-      }
-    engines: { node: ">=0.12" }
-    dev: true
-
-  /error-ex@1.3.2:
-    resolution:
-      {
-        integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==,
-      }
+  /esbuild-sass-plugin@2.16.1(esbuild@0.19.12):
+    resolution: {integrity: sha512-mBB2aEF0xk7yo+Q9pSUh8xYED/1O2wbAM6IauGkDrqy6pl9SbJNakLeLGXiNpNujWIudu8TJTZCv2L5AQYRXtA==}
+    peerDependencies:
+      esbuild: ^0.19.4
     dependencies:
-      is-arrayish: 0.2.1
+      esbuild: 0.19.12
+      resolve: 1.22.8
+      sass: 1.74.1
     dev: true
 
-  /esbuild@0.16.17:
-    resolution:
-      {
-        integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==,
-      }
-    engines: { node: ">=12" }
+  /esbuild@0.19.12:
+    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
+    engines: {node: '>=12'}
+    hasBin: true
     requiresBuild: true
     optionalDependencies:
-      "@esbuild/android-arm": 0.16.17
-      "@esbuild/android-arm64": 0.16.17
-      "@esbuild/android-x64": 0.16.17
-      "@esbuild/darwin-arm64": 0.16.17
-      "@esbuild/darwin-x64": 0.16.17
-      "@esbuild/freebsd-arm64": 0.16.17
-      "@esbuild/freebsd-x64": 0.16.17
-      "@esbuild/linux-arm": 0.16.17
-      "@esbuild/linux-arm64": 0.16.17
-      "@esbuild/linux-ia32": 0.16.17
-      "@esbuild/linux-loong64": 0.16.17
-      "@esbuild/linux-mips64el": 0.16.17
-      "@esbuild/linux-ppc64": 0.16.17
-      "@esbuild/linux-riscv64": 0.16.17
-      "@esbuild/linux-s390x": 0.16.17
-      "@esbuild/linux-x64": 0.16.17
-      "@esbuild/netbsd-x64": 0.16.17
-      "@esbuild/openbsd-x64": 0.16.17
-      "@esbuild/sunos-x64": 0.16.17
-      "@esbuild/win32-arm64": 0.16.17
-      "@esbuild/win32-ia32": 0.16.17
-      "@esbuild/win32-x64": 0.16.17
+      '@esbuild/aix-ppc64': 0.19.12
+      '@esbuild/android-arm': 0.19.12
+      '@esbuild/android-arm64': 0.19.12
+      '@esbuild/android-x64': 0.19.12
+      '@esbuild/darwin-arm64': 0.19.12
+      '@esbuild/darwin-x64': 0.19.12
+      '@esbuild/freebsd-arm64': 0.19.12
+      '@esbuild/freebsd-x64': 0.19.12
+      '@esbuild/linux-arm': 0.19.12
+      '@esbuild/linux-arm64': 0.19.12
+      '@esbuild/linux-ia32': 0.19.12
+      '@esbuild/linux-loong64': 0.19.12
+      '@esbuild/linux-mips64el': 0.19.12
+      '@esbuild/linux-ppc64': 0.19.12
+      '@esbuild/linux-riscv64': 0.19.12
+      '@esbuild/linux-s390x': 0.19.12
+      '@esbuild/linux-x64': 0.19.12
+      '@esbuild/netbsd-x64': 0.19.12
+      '@esbuild/openbsd-x64': 0.19.12
+      '@esbuild/sunos-x64': 0.19.12
+      '@esbuild/win32-arm64': 0.19.12
+      '@esbuild/win32-ia32': 0.19.12
+      '@esbuild/win32-x64': 0.19.12
     dev: true
 
-  /escalade@3.1.1:
-    resolution:
-      {
-        integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==,
-      }
-    engines: { node: ">=6" }
+  /escalade@3.1.2:
+    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+    engines: {node: '>=6'}
     dev: true
 
   /escape-goat@4.0.0:
-    resolution:
-      {
-        integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==}
+    engines: {node: '>=12'}
     dev: true
 
-  /escape-string-regexp@1.0.5:
-    resolution:
-      {
-        integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==,
-      }
-    engines: { node: ">=0.8.0" }
+  /esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
     dev: true
 
   /fetch-blob@3.2.0:
-    resolution:
-      {
-        integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==,
-      }
-    engines: { node: ^12.20 || >= 14.13 }
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
     dependencies:
       node-domexception: 1.0.0
-      web-streams-polyfill: 3.2.1
+      web-streams-polyfill: 3.3.3
     dev: true
 
   /fill-range@7.0.1:
-    resolution:
-      {
-        integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
     dev: true
 
   /form-data-encoder@2.1.4:
-    resolution:
-      {
-        integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==,
-      }
-    engines: { node: ">= 14.17" }
+    resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
+    engines: {node: '>= 14.17'}
     dev: true
 
   /formdata-polyfill@4.0.10:
-    resolution:
-      {
-        integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==,
-      }
-    engines: { node: ">=12.20.0" }
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
     dependencies:
       fetch-blob: 3.2.0
     dev: true
 
   /fs.realpath@1.0.0:
-    resolution:
-      {
-        integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==,
-      }
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution:
-      {
-        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
-      }
-    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
+  /function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    dev: true
+
   /get-caller-file@2.0.5:
-    resolution:
-      {
-        integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
-      }
-    engines: { node: 6.* || 8.* || >= 10.* }
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
 
   /get-stream@6.0.1:
-    resolution:
-      {
-        integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /get-tsconfig@4.7.3:
+    resolution: {integrity: sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
     dev: true
 
   /glob-parent@5.1.2:
-    resolution:
-      {
-        integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
     dev: true
 
   /glob@7.2.3:
-    resolution:
-      {
-        integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==,
-      }
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -2572,915 +870,315 @@ packages:
     dev: true
 
   /global-dirs@3.0.1:
-    resolution:
-      {
-        integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
+    engines: {node: '>=10'}
     dependencies:
       ini: 2.0.0
     dev: true
 
-  /globals@13.20.0:
-    resolution:
-      {
-        integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==,
-      }
-    engines: { node: ">=8" }
+  /got@12.6.1:
+    resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
+    engines: {node: '>=14.16'}
     dependencies:
-      type-fest: 0.20.2
-    dev: true
-
-  /got@12.6.0:
-    resolution:
-      {
-        integrity: sha512-WTcaQ963xV97MN3x0/CbAriXFZcXCfgxVp91I+Ze6pawQOa7SgzwSx2zIJJsX+kTajMnVs0xcFD1TxZKFqhdnQ==,
-      }
-    engines: { node: ">=14.16" }
-    dependencies:
-      "@sindresorhus/is": 5.3.0
-      "@szmarczak/http-timer": 5.0.1
+      '@sindresorhus/is': 5.6.0
+      '@szmarczak/http-timer': 5.0.1
       cacheable-lookup: 7.0.0
-      cacheable-request: 10.2.9
+      cacheable-request: 10.2.14
       decompress-response: 6.0.0
       form-data-encoder: 2.1.4
       get-stream: 6.0.1
-      http2-wrapper: 2.2.0
+      http2-wrapper: 2.2.1
       lowercase-keys: 3.0.0
       p-cancelable: 3.0.0
       responselike: 3.0.0
     dev: true
 
   /graceful-fs@4.2.10:
-    resolution:
-      {
-        integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==,
-      }
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
     dev: true
 
   /graceful-fs@4.2.11:
-    resolution:
-      {
-        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-      }
-    dev: true
-
-  /has-flag@3.0.0:
-    resolution:
-      {
-        integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==,
-      }
-    engines: { node: ">=4" }
-    dev: true
-
-  /has-flag@4.0.0:
-    resolution:
-      {
-        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
 
   /has-yarn@3.0.0:
-    resolution:
-      {
-        integrity: sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    resolution: {integrity: sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
-  /htmlnano@2.0.3(svgo@2.8.0):
-    resolution:
-      {
-        integrity: sha512-S4PGGj9RbdgW8LhbILNK7W9JhmYP8zmDY7KDV/8eCiJBQJlbmltp5I0gv8c5ntLljfdxxfmJ+UJVSqyH4mb41A==,
-      }
-    peerDependencies:
-      cssnano: ^5.0.11
-      postcss: ^8.3.11
-      purgecss: ^5.0.0
-      relateurl: ^0.2.7
-      srcset: 4.0.0
-      svgo: ^2.8.0
-      terser: ^5.10.0
-      uncss: ^0.17.3
-    peerDependenciesMeta:
-      cssnano:
-        optional: true
-      postcss:
-        optional: true
-      purgecss:
-        optional: true
-      relateurl:
-        optional: true
-      srcset:
-        optional: true
-      svgo:
-        optional: true
-      terser:
-        optional: true
-      uncss:
-        optional: true
+  /hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
     dependencies:
-      cosmiconfig: 7.1.0
-      posthtml: 0.16.6
-      svgo: 2.8.0
-      timsort: 0.3.0
-    dev: true
-
-  /htmlparser2@7.2.0:
-    resolution:
-      {
-        integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==,
-      }
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
-      entities: 3.0.1
+      function-bind: 1.1.2
     dev: true
 
   /http-cache-semantics@4.1.1:
-    resolution:
-      {
-        integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==,
-      }
+    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
     dev: true
 
-  /http2-wrapper@2.2.0:
-    resolution:
-      {
-        integrity: sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==,
-      }
-    engines: { node: ">=10.19.0" }
+  /http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
+    engines: {node: '>=10.19.0'}
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
     dev: true
 
-  /immutable@4.3.0:
-    resolution:
-      {
-        integrity: sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==,
-      }
-    dev: true
-
-  /import-fresh@3.3.0:
-    resolution:
-      {
-        integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==,
-      }
-    engines: { node: ">=6" }
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
+  /immutable@4.3.5:
+    resolution: {integrity: sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==}
     dev: true
 
   /import-lazy@4.0.0:
-    resolution:
-      {
-        integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
     dev: true
 
   /imurmurhash@0.1.4:
-    resolution:
-      {
-        integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
-      }
-    engines: { node: ">=0.8.19" }
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
     dev: true
 
   /inflight@1.0.6:
-    resolution:
-      {
-        integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==,
-      }
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
     dev: true
 
   /inherits@2.0.4:
-    resolution:
-      {
-        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
-      }
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
 
   /ini@1.3.8:
-    resolution:
-      {
-        integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
-      }
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
     dev: true
 
   /ini@2.0.0:
-    resolution:
-      {
-        integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==,
-      }
-    engines: { node: ">=10" }
-    dev: true
-
-  /is-arrayish@0.2.1:
-    resolution:
-      {
-        integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
-      }
+    resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
+    engines: {node: '>=10'}
     dev: true
 
   /is-binary-path@2.1.0:
-    resolution:
-      {
-        integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
     dependencies:
-      binary-extensions: 2.2.0
+      binary-extensions: 2.3.0
     dev: true
 
   /is-ci@3.0.1:
-    resolution:
-      {
-        integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==,
-      }
+    resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
+    hasBin: true
     dependencies:
-      ci-info: 3.8.0
+      ci-info: 3.9.0
+    dev: true
+
+  /is-core-module@2.13.1:
+    resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
+    dependencies:
+      hasown: 2.0.2
     dev: true
 
   /is-extglob@2.1.1:
-    resolution:
-      {
-        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /is-fullwidth-code-point@3.0.0:
-    resolution:
-      {
-        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
     dev: true
 
   /is-glob@4.0.3:
-    resolution:
-      {
-        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
     dev: true
 
   /is-installed-globally@0.4.0:
-    resolution:
-      {
-        integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
+    engines: {node: '>=10'}
     dependencies:
       global-dirs: 3.0.1
       is-path-inside: 3.0.3
     dev: true
 
-  /is-json@2.0.1:
-    resolution:
-      {
-        integrity: sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==,
-      }
-    dev: true
-
   /is-npm@6.0.0:
-    resolution:
-      {
-        integrity: sha512-JEjxbSmtPSt1c8XTkVrlujcXdKV1/tvuQ7GwKcAlyiVLeYFQ2VHat8xfrDJsIkhCdF/tZ7CiIR3sy141c6+gPQ==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    resolution: {integrity: sha512-JEjxbSmtPSt1c8XTkVrlujcXdKV1/tvuQ7GwKcAlyiVLeYFQ2VHat8xfrDJsIkhCdF/tZ7CiIR3sy141c6+gPQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /is-number@7.0.0:
-    resolution:
-      {
-        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
-      }
-    engines: { node: ">=0.12.0" }
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
     dev: true
 
   /is-obj@2.0.0:
-    resolution:
-      {
-        integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
     dev: true
 
   /is-path-inside@3.0.3:
-    resolution:
-      {
-        integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==,
-      }
-    engines: { node: ">=8" }
-    dev: true
-
-  /is-plain-object@5.0.0:
-    resolution:
-      {
-        integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
     dev: true
 
   /is-typedarray@1.0.0:
-    resolution:
-      {
-        integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==,
-      }
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
     dev: true
 
   /is-yarn-global@0.4.1:
-    resolution:
-      {
-        integrity: sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==,
-      }
-    engines: { node: ">=12" }
-    dev: true
-
-  /js-tokens@4.0.0:
-    resolution:
-      {
-        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
-      }
+    resolution: {integrity: sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /json-buffer@3.0.1:
-    resolution:
-      {
-        integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
-      }
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
     dev: true
 
-  /json-parse-even-better-errors@2.3.1:
-    resolution:
-      {
-        integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
-      }
-    dev: true
-
-  /json5@2.2.3:
-    resolution:
-      {
-        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
-      }
-    engines: { node: ">=6" }
-    dev: true
-
-  /keyv@4.5.2:
-    resolution:
-      {
-        integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==,
-      }
+  /keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
       json-buffer: 3.0.1
     dev: true
 
+  /kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+    dev: true
+
   /latest-version@7.0.0:
-    resolution:
-      {
-        integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==,
-      }
-    engines: { node: ">=14.16" }
+    resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
+    engines: {node: '>=14.16'}
     dependencies:
-      package-json: 8.1.0
-    dev: true
-
-  /lightningcss-darwin-arm64@1.19.0:
-    resolution:
-      {
-        integrity: sha512-wIJmFtYX0rXHsXHSr4+sC5clwblEMji7HHQ4Ub1/CznVRxtCFha6JIt5JZaNf8vQrfdZnBxLLC6R8pC818jXqg==,
-      }
-    engines: { node: ">= 12.0.0" }
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-darwin-x64@1.19.0:
-    resolution:
-      {
-        integrity: sha512-Lif1wD6P4poaw9c/4Uh2z+gmrWhw/HtXFoeZ3bEsv6Ia4tt8rOJBdkfVaUJ6VXmpKHALve+iTyP2+50xY1wKPw==,
-      }
-    engines: { node: ">= 12.0.0" }
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-linux-arm-gnueabihf@1.19.0:
-    resolution:
-      {
-        integrity: sha512-P15VXY5682mTXaiDtbnLYQflc8BYb774j2R84FgDLJTN6Qp0ZjWEFyN1SPqyfTj2B2TFjRHRUvQSSZ7qN4Weig==,
-      }
-    engines: { node: ">= 12.0.0" }
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-linux-arm64-gnu@1.19.0:
-    resolution:
-      {
-        integrity: sha512-zwXRjWqpev8wqO0sv0M1aM1PpjHz6RVIsBcxKszIG83Befuh4yNysjgHVplF9RTU7eozGe3Ts7r6we1+Qkqsww==,
-      }
-    engines: { node: ">= 12.0.0" }
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-linux-arm64-musl@1.19.0:
-    resolution:
-      {
-        integrity: sha512-vSCKO7SDnZaFN9zEloKSZM5/kC5gbzUjoJQ43BvUpyTFUX7ACs/mDfl2Eq6fdz2+uWhUh7vf92c4EaaP4udEtA==,
-      }
-    engines: { node: ">= 12.0.0" }
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-linux-x64-gnu@1.19.0:
-    resolution:
-      {
-        integrity: sha512-0AFQKvVzXf9byrXUq9z0anMGLdZJS+XSDqidyijI5njIwj6MdbvX2UZK/c4FfNmeRa2N/8ngTffoIuOUit5eIQ==,
-      }
-    engines: { node: ">= 12.0.0" }
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-linux-x64-musl@1.19.0:
-    resolution:
-      {
-        integrity: sha512-SJoM8CLPt6ECCgSuWe+g0qo8dqQYVcPiW2s19dxkmSI5+Uu1GIRzyKA0b7QqmEXolA+oSJhQqCmJpzjY4CuZAg==,
-      }
-    engines: { node: ">= 12.0.0" }
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-win32-x64-msvc@1.19.0:
-    resolution:
-      {
-        integrity: sha512-C+VuUTeSUOAaBZZOPT7Etn/agx/MatzJzGRkeV+zEABmPuntv1zihncsi+AyGmjkkzq3wVedEy7h0/4S84mUtg==,
-      }
-    engines: { node: ">= 12.0.0" }
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss@1.19.0:
-    resolution:
-      {
-        integrity: sha512-yV5UR7og+Og7lQC+70DA7a8ta1uiOPnWPJfxa0wnxylev5qfo4P+4iMpzWAdYWOca4jdNQZii+bDL/l+4hUXIA==,
-      }
-    engines: { node: ">= 12.0.0" }
-    dependencies:
-      detect-libc: 1.0.3
-    optionalDependencies:
-      lightningcss-darwin-arm64: 1.19.0
-      lightningcss-darwin-x64: 1.19.0
-      lightningcss-linux-arm-gnueabihf: 1.19.0
-      lightningcss-linux-arm64-gnu: 1.19.0
-      lightningcss-linux-arm64-musl: 1.19.0
-      lightningcss-linux-x64-gnu: 1.19.0
-      lightningcss-linux-x64-musl: 1.19.0
-      lightningcss-win32-x64-msvc: 1.19.0
-    dev: true
-
-  /lines-and-columns@1.2.4:
-    resolution:
-      {
-        integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
-      }
-    dev: true
-
-  /lmdb@2.5.2:
-    resolution:
-      {
-        integrity: sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==,
-      }
-    requiresBuild: true
-    dependencies:
-      msgpackr: 1.8.5
-      node-addon-api: 4.3.0
-      node-gyp-build-optional-packages: 5.0.3
-      ordered-binary: 1.4.0
-      weak-lru-cache: 1.2.2
-    optionalDependencies:
-      "@lmdb/lmdb-darwin-arm64": 2.5.2
-      "@lmdb/lmdb-darwin-x64": 2.5.2
-      "@lmdb/lmdb-linux-arm": 2.5.2
-      "@lmdb/lmdb-linux-arm64": 2.5.2
-      "@lmdb/lmdb-linux-x64": 2.5.2
-      "@lmdb/lmdb-win32-x64": 2.5.2
+      package-json: 8.1.1
     dev: true
 
   /lowercase-keys@3.0.0:
-    resolution:
-      {
-        integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /lru-cache@6.0.0:
-    resolution:
-      {
-        integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
     dev: true
 
-  /mdn-data@2.0.14:
-    resolution:
-      {
-        integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==,
-      }
-    dev: true
-
-  /micromatch@4.0.5:
-    resolution:
-      {
-        integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==,
-      }
-    engines: { node: ">=8.6" }
-    dependencies:
-      braces: 3.0.2
-      picomatch: 2.3.1
-    dev: true
-
   /mimic-response@3.1.0:
-    resolution:
-      {
-        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
     dev: true
 
   /mimic-response@4.0.0:
-    resolution:
-      {
-        integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /minimatch@3.1.2:
-    resolution:
-      {
-        integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
-      }
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
     dev: true
 
   /minimist@1.2.8:
-    resolution:
-      {
-        integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
-      }
-    dev: true
-
-  /msgpackr-extract@3.0.2:
-    resolution:
-      {
-        integrity: sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==,
-      }
-    requiresBuild: true
-    dependencies:
-      node-gyp-build-optional-packages: 5.0.7
-    optionalDependencies:
-      "@msgpackr-extract/msgpackr-extract-darwin-arm64": 3.0.2
-      "@msgpackr-extract/msgpackr-extract-darwin-x64": 3.0.2
-      "@msgpackr-extract/msgpackr-extract-linux-arm": 3.0.2
-      "@msgpackr-extract/msgpackr-extract-linux-arm64": 3.0.2
-      "@msgpackr-extract/msgpackr-extract-linux-x64": 3.0.2
-      "@msgpackr-extract/msgpackr-extract-win32-x64": 3.0.2
-    dev: true
-    optional: true
-
-  /msgpackr@1.8.5:
-    resolution:
-      {
-        integrity: sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==,
-      }
-    optionalDependencies:
-      msgpackr-extract: 3.0.2
-    dev: true
-
-  /node-addon-api@3.2.1:
-    resolution:
-      {
-        integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==,
-      }
-    dev: true
-
-  /node-addon-api@4.3.0:
-    resolution:
-      {
-        integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==,
-      }
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
 
   /node-domexception@1.0.0:
-    resolution:
-      {
-        integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==,
-      }
-    engines: { node: ">=10.5.0" }
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
     dev: true
 
-  /node-fetch@2.6.9:
-    resolution:
-      {
-        integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==,
-      }
-    engines: { node: 4.x || >=6.0.0 }
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
-    dev: true
-
-  /node-fetch@3.3.1:
-    resolution:
-      {
-        integrity: sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+  /node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
     dev: true
 
-  /node-gyp-build-optional-packages@5.0.3:
-    resolution:
-      {
-        integrity: sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==,
-      }
-    dev: true
-
-  /node-gyp-build-optional-packages@5.0.7:
-    resolution:
-      {
-        integrity: sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==,
-      }
-    dev: true
-    optional: true
-
-  /node-gyp-build@4.6.0:
-    resolution:
-      {
-        integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==,
-      }
-    dev: true
-
-  /node-releases@2.0.10:
-    resolution:
-      {
-        integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==,
-      }
-    dev: true
-
   /normalize-path@3.0.0:
-    resolution:
-      {
-        integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
-  /normalize-url@8.0.0:
-    resolution:
-      {
-        integrity: sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==,
-      }
-    engines: { node: ">=14.16" }
-    dev: true
-
-  /nth-check@2.1.1:
-    resolution:
-      {
-        integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
-      }
-    dependencies:
-      boolbase: 1.0.0
-    dev: true
-
-  /nullthrows@1.1.1:
-    resolution:
-      {
-        integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==,
-      }
+  /normalize-url@8.0.1:
+    resolution: {integrity: sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==}
+    engines: {node: '>=14.16'}
     dev: true
 
   /once@1.4.0:
-    resolution:
-      {
-        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
-      }
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: true
 
-  /ordered-binary@1.4.0:
-    resolution:
-      {
-        integrity: sha512-EHQ/jk4/a9hLupIKxTfUsQRej1Yd/0QLQs3vGvIqg5ZtCYSzNhkzHoZc7Zf4e4kUlDaC3Uw8Q/1opOLNN2OKRQ==,
-      }
-    dev: true
-
   /p-cancelable@3.0.0:
-    resolution:
-      {
-        integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==,
-      }
-    engines: { node: ">=12.20" }
+    resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
+    engines: {node: '>=12.20'}
     dev: true
 
-  /package-json@8.1.0:
-    resolution:
-      {
-        integrity: sha512-hySwcV8RAWeAfPsXb9/HGSPn8lwDnv6fabH+obUZKX169QknRkRhPxd1yMubpKDskLFATkl3jHpNtVtDPFA0Wg==,
-      }
-    engines: { node: ">=14.16" }
+  /package-json@8.1.1:
+    resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
+    engines: {node: '>=14.16'}
     dependencies:
-      got: 12.6.0
+      got: 12.6.1
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.3.8
-    dev: true
-
-  /parent-module@1.0.1:
-    resolution:
-      {
-        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
-      }
-    engines: { node: ">=6" }
-    dependencies:
-      callsites: 3.1.0
-    dev: true
-
-  /parse-json@5.2.0:
-    resolution:
-      {
-        integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==,
-      }
-    engines: { node: ">=8" }
-    dependencies:
-      "@babel/code-frame": 7.21.4
-      error-ex: 1.3.2
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.2.4
+      semver: 7.6.0
     dev: true
 
   /path-is-absolute@1.0.1:
-    resolution:
-      {
-        integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
-  /path-type@4.0.0:
-    resolution:
-      {
-        integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
-      }
-    engines: { node: ">=8" }
-    dev: true
-
-  /picocolors@1.0.0:
-    resolution:
-      {
-        integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==,
-      }
+  /path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
   /picomatch@2.3.1:
-    resolution:
-      {
-        integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
-      }
-    engines: { node: ">=8.6" }
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
     dev: true
 
-  /postcss-value-parser@4.2.0:
-    resolution:
-      {
-        integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
-      }
+  /prettier@3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
+    engines: {node: '>=14'}
+    hasBin: true
     dev: true
 
-  /posthtml-parser@0.10.2:
-    resolution:
-      {
-        integrity: sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==,
-      }
-    engines: { node: ">=12" }
+  /prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
     dependencies:
-      htmlparser2: 7.2.0
-    dev: true
-
-  /posthtml-parser@0.11.0:
-    resolution:
-      {
-        integrity: sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==,
-      }
-    engines: { node: ">=12" }
-    dependencies:
-      htmlparser2: 7.2.0
-    dev: true
-
-  /posthtml-render@3.0.0:
-    resolution:
-      {
-        integrity: sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==,
-      }
-    engines: { node: ">=12" }
-    dependencies:
-      is-json: 2.0.1
-    dev: true
-
-  /posthtml@0.16.6:
-    resolution:
-      {
-        integrity: sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==,
-      }
-    engines: { node: ">=12.0.0" }
-    dependencies:
-      posthtml-parser: 0.11.0
-      posthtml-render: 3.0.0
-    dev: true
-
-  /prettier@2.8.7:
-    resolution:
-      {
-        integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==,
-      }
-    engines: { node: ">=10.13.0" }
+      kleur: 3.0.3
+      sisteransi: 1.0.5
     dev: true
 
   /proto-list@1.2.4:
-    resolution:
-      {
-        integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==,
-      }
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
     dev: true
 
   /pupa@3.1.0:
-    resolution:
-      {
-        integrity: sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==,
-      }
-    engines: { node: ">=12.20" }
+    resolution: {integrity: sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==}
+    engines: {node: '>=12.20'}
     dependencies:
       escape-goat: 4.0.0
     dev: true
 
   /quick-lru@5.1.1:
-    resolution:
-      {
-        integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
     dev: true
 
   /rc@1.2.8:
-    resolution:
-      {
-        integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==,
-      }
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
@@ -3488,238 +1186,138 @@ packages:
       strip-json-comments: 2.0.1
     dev: true
 
-  /react-error-overlay@6.0.9:
-    resolution:
-      {
-        integrity: sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==,
-      }
-    dev: true
-
-  /react-refresh@0.9.0:
-    resolution:
-      {
-        integrity: sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==,
-      }
-    engines: { node: ">=0.10.0" }
-    dev: true
-
   /readdirp@3.6.0:
-    resolution:
-      {
-        integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
-      }
-    engines: { node: ">=8.10.0" }
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
     dev: true
 
-  /regenerator-runtime@0.13.11:
-    resolution:
-      {
-        integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==,
-      }
-    dev: true
-
   /registry-auth-token@5.0.2:
-    resolution:
-      {
-        integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==,
-      }
-    engines: { node: ">=14" }
+    resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
+    engines: {node: '>=14'}
     dependencies:
-      "@pnpm/npm-conf": 2.1.0
+      '@pnpm/npm-conf': 2.2.2
     dev: true
 
   /registry-url@6.0.1:
-    resolution:
-      {
-        integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
+    engines: {node: '>=12'}
     dependencies:
       rc: 1.2.8
     dev: true
 
-  /replugged@4.2.3(@codemirror/view@6.9.3)(@lezer/common@1.0.2):
-    resolution:
-      {
-        integrity: sha512-11X9a07lf1CqEqEbM6Clw7I+jMnSkH1v1ZEVtM7XBFbyFNqThCKiSTuN4VaG7MoFi0smyxsfozL5wzCvL8a61w==,
-      }
-    engines: { node: ">=14.0.0" }
+  /replugged@4.7.9(@codemirror/view@6.26.1)(@lezer/common@1.2.1):
+    resolution: {integrity: sha512-Eh44KEzXVLRO7UtrZm5mvYXr12KJV4zpifYUEFlNoGaT9mzO598f8WgiMdCQdaUf27bZl+nk6qUngMR4YfkXoA==}
+    engines: {node: '>=18.0.0', pnpm: '>=8.0.0'}
+    hasBin: true
+    requiresBuild: true
     dependencies:
-      "@codemirror/lang-css": 6.1.1(@codemirror/view@6.9.3)(@lezer/common@1.0.2)
-      "@codemirror/language": 6.6.0
-      "@codemirror/state": 6.2.0
-      "@ddietr/codemirror-themes": 1.4.0
-      "@electron/asar": 3.2.3
-      "@lezer/highlight": 1.1.4
-      "@octokit/rest": 19.0.7
-      "@parcel/config-default": 2.8.3(@parcel/core@2.8.3)
-      "@parcel/core": 2.8.3
-      "@parcel/transformer-sass": 2.8.3(@parcel/core@2.8.3)
-      chalk: 5.2.0
-      codemirror: 6.0.1(@lezer/common@1.0.2)
-      esbuild: 0.16.17
-      node-fetch: 3.3.1
+      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.26.1)
+      '@codemirror/language': 6.10.1
+      '@codemirror/state': 6.4.1
+      '@ddietr/codemirror-themes': 1.4.2
+      '@electron/asar': 3.2.9
+      '@lezer/highlight': 1.2.0
+      '@octokit/rest': 20.1.0
+      adm-zip: 0.5.12
+      chalk: 5.3.0
+      codemirror: 6.0.1(@lezer/common@1.2.1)
+      esbuild: 0.19.12
+      esbuild-sass-plugin: 2.16.1(esbuild@0.19.12)
+      esm: 3.2.25
+      node-fetch: 3.3.2
+      prompts: 2.4.2
+      semver: 7.6.0
       standalone-electron-types: 1.0.0
+      tsx: 4.7.2
       update-notifier: 6.0.2
-      yargs: 17.7.1
-      zod: 3.21.4
+      ws: 8.16.0
+      yargs: 17.7.2
+      zod: 3.22.4
     transitivePeerDependencies:
-      - "@codemirror/view"
-      - "@lezer/common"
-      - cssnano
-      - encoding
-      - postcss
-      - purgecss
-      - relateurl
-      - srcset
-      - terser
-      - uncss
+      - '@codemirror/view'
+      - '@lezer/common'
+      - bufferutil
+      - utf-8-validate
     dev: true
 
   /require-directory@2.1.1:
-    resolution:
-      {
-        integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /resolve-alpn@1.2.1:
-    resolution:
-      {
-        integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==,
-      }
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
     dev: true
 
-  /resolve-from@4.0.0:
-    resolution:
-      {
-        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
-      }
-    engines: { node: ">=4" }
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
+  /resolve@1.22.8:
+    resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.13.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
   /responselike@3.0.0:
-    resolution:
-      {
-        integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==,
-      }
-    engines: { node: ">=14.16" }
+    resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
+    engines: {node: '>=14.16'}
     dependencies:
       lowercase-keys: 3.0.0
     dev: true
 
-  /safe-buffer@5.2.1:
-    resolution:
-      {
-        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
-      }
-    dev: true
-
-  /sass@1.60.0:
-    resolution:
-      {
-        integrity: sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==,
-      }
-    engines: { node: ">=12.0.0" }
+  /sass@1.74.1:
+    resolution: {integrity: sha512-w0Z9p/rWZWelb88ISOLyvqTWGmtmu2QJICqDBGyNnfG4OUnPX9BBjjYIXUpXCMOOg5MQWNpqzt876la1fsTvUA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
     dependencies:
-      chokidar: 3.5.3
-      immutable: 4.3.0
-      source-map-js: 1.0.2
+      chokidar: 3.6.0
+      immutable: 4.3.5
+      source-map-js: 1.2.0
     dev: true
 
   /semver-diff@4.0.0:
-    resolution:
-      {
-        integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
+    engines: {node: '>=12'}
     dependencies:
-      semver: 7.3.8
+      semver: 7.6.0
     dev: true
 
-  /semver@5.7.1:
-    resolution:
-      {
-        integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==,
-      }
-    dev: true
-
-  /semver@7.3.8:
-    resolution:
-      {
-        integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==,
-      }
-    engines: { node: ">=10" }
+  /semver@7.6.0:
+    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
+    engines: {node: '>=10'}
+    hasBin: true
     dependencies:
       lru-cache: 6.0.0
     dev: true
 
   /signal-exit@3.0.7:
-    resolution:
-      {
-        integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
-      }
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
 
-  /source-map-js@1.0.2:
-    resolution:
-      {
-        integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==,
-      }
-    engines: { node: ">=0.10.0" }
+  /sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
 
-  /source-map-support@0.5.21:
-    resolution:
-      {
-        integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
-      }
-    dependencies:
-      buffer-from: 1.1.2
-      source-map: 0.6.1
-    dev: true
-
-  /source-map@0.6.1:
-    resolution:
-      {
-        integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
-      }
-    engines: { node: ">=0.10.0" }
-    dev: true
-
-  /srcset@4.0.0:
-    resolution:
-      {
-        integrity: sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==,
-      }
-    engines: { node: ">=12" }
-    dev: true
-
-  /stable@0.1.8:
-    resolution:
-      {
-        integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==,
-      }
+  /source-map-js@1.2.0:
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /standalone-electron-types@1.0.0:
-    resolution:
-      {
-        integrity: sha512-0HOi/tlTz3mjWhsAz4uRbpQcHMZ+ifj1JzWW9nugykOHClBBG77ps8QinrzX1eow4Iw2pnC+RFaSYRgufF4BOg==,
-      }
+    resolution: {integrity: sha512-0HOi/tlTz3mjWhsAz4uRbpQcHMZ+ifj1JzWW9nugykOHClBBG77ps8QinrzX1eow4Iw2pnC+RFaSYRgufF4BOg==}
     dependencies:
-      "@types/node": 18.15.11
+      '@types/node': 18.19.29
     dev: true
 
   /string-width@4.2.3:
-    resolution:
-      {
-        integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
@@ -3727,204 +1325,97 @@ packages:
     dev: true
 
   /string-width@5.1.2:
-    resolution:
-      {
-        integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
     dev: true
 
   /strip-ansi@6.0.1:
-    resolution:
-      {
-        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
     dev: true
 
-  /strip-ansi@7.0.1:
-    resolution:
-      {
-        integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==,
-      }
-    engines: { node: ">=12" }
+  /strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
     dev: true
 
   /strip-json-comments@2.0.1:
-    resolution:
-      {
-        integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
-  /style-mod@4.0.2:
-    resolution:
-      {
-        integrity: sha512-C4myMmRTO8iaC5Gg+N1ftK2WT4eXUTMAa+HEFPPrfVeO/NtqLTtAmV1HbqnuGtLwCek44Ra76fdGUkSqjiMPcQ==,
-      }
+  /style-mod@4.1.2:
+    resolution: {integrity: sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==}
     dev: true
 
-  /supports-color@5.5.0:
-    resolution:
-      {
-        integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==,
-      }
-    engines: { node: ">=4" }
-    dependencies:
-      has-flag: 3.0.0
-    dev: true
-
-  /supports-color@7.2.0:
-    resolution:
-      {
-        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
-      }
-    engines: { node: ">=8" }
-    dependencies:
-      has-flag: 4.0.0
-    dev: true
-
-  /svgo@2.8.0:
-    resolution:
-      {
-        integrity: sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==,
-      }
-    engines: { node: ">=10.13.0" }
-    dependencies:
-      "@trysound/sax": 0.2.0
-      commander: 7.2.0
-      css-select: 4.3.0
-      css-tree: 1.1.3
-      csso: 4.2.0
-      picocolors: 1.0.0
-      stable: 0.1.8
-    dev: true
-
-  /terser@5.16.8:
-    resolution:
-      {
-        integrity: sha512-QI5g1E/ef7d+PsDifb+a6nnVgC4F22Bg6T0xrBrz6iloVB4PUkkunp6V8nzoOOZJIzjWVdAGqCdlKlhLq/TbIA==,
-      }
-    engines: { node: ">=10" }
-    dependencies:
-      "@jridgewell/source-map": 0.3.2
-      acorn: 8.8.2
-      commander: 2.20.3
-      source-map-support: 0.5.21
-    dev: true
-
-  /timsort@0.3.0:
-    resolution:
-      {
-        integrity: sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==,
-      }
+  /supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /to-regex-range@5.0.1:
-    resolution:
-      {
-        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
-      }
-    engines: { node: ">=8.0" }
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
     dev: true
 
-  /tr46@0.0.3:
-    resolution:
-      {
-        integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
-      }
-    dev: true
-
-  /tslib@2.5.0:
-    resolution:
-      {
-        integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==,
-      }
-    dev: true
-
-  /type-fest@0.20.2:
-    resolution:
-      {
-        integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==,
-      }
-    engines: { node: ">=10" }
+  /tsx@4.7.2:
+    resolution: {integrity: sha512-BCNd4kz6fz12fyrgCTEdZHGJ9fWTGeUzXmQysh0RVocDY3h4frk05ZNCXSy4kIenF7y/QnrdiVpTsyNRn6vlAw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.19.12
+      get-tsconfig: 4.7.3
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /type-fest@1.4.0:
-    resolution:
-      {
-        integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
     dev: true
 
   /type-fest@2.19.0:
-    resolution:
-      {
-        integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==,
-      }
-    engines: { node: ">=12.20" }
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
     dev: true
 
   /typedarray-to-buffer@3.1.5:
-    resolution:
-      {
-        integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==,
-      }
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
     dev: true
 
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
+
   /unique-string@3.0.0:
-    resolution:
-      {
-        integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
+    engines: {node: '>=12'}
     dependencies:
       crypto-random-string: 4.0.0
     dev: true
 
-  /universal-user-agent@6.0.0:
-    resolution:
-      {
-        integrity: sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==,
-      }
-    dev: true
-
-  /update-browserslist-db@1.0.10(browserslist@4.21.5):
-    resolution:
-      {
-        integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==,
-      }
-    peerDependencies:
-      browserslist: ">= 4.21.0"
-    dependencies:
-      browserslist: 4.21.5
-      escalade: 3.1.1
-      picocolors: 1.0.0
+  /universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
     dev: true
 
   /update-notifier@6.0.2:
-    resolution:
-      {
-        integrity: sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==,
-      }
-    engines: { node: ">=14.16" }
+    resolution: {integrity: sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==}
+    engines: {node: '>=14.16'}
     dependencies:
-      boxen: 7.0.2
-      chalk: 5.2.0
+      boxen: 7.1.1
+      chalk: 5.3.0
       configstore: 6.0.0
       has-yarn: 3.0.0
       import-lazy: 4.0.0
@@ -3934,74 +1425,30 @@ packages:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.3.8
+      semver: 7.6.0
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true
 
-  /utility-types@3.10.0:
-    resolution:
-      {
-        integrity: sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==,
-      }
-    engines: { node: ">= 4" }
+  /w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
     dev: true
 
-  /w3c-keyname@2.2.6:
-    resolution:
-      {
-        integrity: sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==,
-      }
-    dev: true
-
-  /weak-lru-cache@1.2.2:
-    resolution:
-      {
-        integrity: sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==,
-      }
-    dev: true
-
-  /web-streams-polyfill@3.2.1:
-    resolution:
-      {
-        integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==,
-      }
-    engines: { node: ">= 8" }
-    dev: true
-
-  /webidl-conversions@3.0.1:
-    resolution:
-      {
-        integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
-      }
-    dev: true
-
-  /whatwg-url@5.0.0:
-    resolution:
-      {
-        integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
-      }
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
+  /web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
     dev: true
 
   /widest-line@4.0.1:
-    resolution:
-      {
-        integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
+    engines: {node: '>=12'}
     dependencies:
       string-width: 5.1.2
     dev: true
 
   /wrap-ansi@7.0.0:
-    resolution:
-      {
-        integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
@@ -4009,29 +1456,20 @@ packages:
     dev: true
 
   /wrap-ansi@8.1.0:
-    resolution:
-      {
-        integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
     dependencies:
       ansi-styles: 6.2.1
       string-width: 5.1.2
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
     dev: true
 
   /wrappy@1.0.2:
-    resolution:
-      {
-        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
-      }
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: true
 
   /write-file-atomic@3.0.3:
-    resolution:
-      {
-        integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==,
-      }
+    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
     dependencies:
       imurmurhash: 0.1.4
       is-typedarray: 1.0.0
@@ -4039,61 +1477,44 @@ packages:
       typedarray-to-buffer: 3.1.5
     dev: true
 
-  /xdg-basedir@5.1.0:
-    resolution:
-      {
-        integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==,
-      }
-    engines: { node: ">=12" }
+  /ws@8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
     dev: true
 
-  /xxhash-wasm@0.4.2:
-    resolution:
-      {
-        integrity: sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==,
-      }
+  /xdg-basedir@5.1.0:
+    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /y18n@5.0.8:
-    resolution:
-      {
-        integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
     dev: true
 
   /yallist@4.0.0:
-    resolution:
-      {
-        integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==,
-      }
-    dev: true
-
-  /yaml@1.10.2:
-    resolution:
-      {
-        integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
   /yargs-parser@21.1.1:
-    resolution:
-      {
-        integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
     dev: true
 
-  /yargs@17.7.1:
-    resolution:
-      {
-        integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==,
-      }
-    engines: { node: ">=12" }
+  /yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.1
+      escalade: 3.1.2
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -4101,9 +1522,6 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /zod@3.21.4:
-    resolution:
-      {
-        integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==,
-      }
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: true

--- a/stuff/_channel-bar.scss
+++ b/stuff/_channel-bar.scss
@@ -185,7 +185,9 @@
     right: 0;
     min-height: 100%;
     max-height: 100% !important;
-    animation: sidebarStatusTransalteXReverse 0.5s ease, fade 0.4s ease;
+    animation:
+      sidebarStatusTransalteXReverse 0.5s ease,
+      fade 0.4s ease;
     border-radius: 0;
 
     // Top

--- a/stuff/_channel-list.scss
+++ b/stuff/_channel-list.scss
@@ -99,7 +99,10 @@
     background: transparent;
   }
 
-  .container__7e23c > .scroller__1f498 > .content__690c5 > div:first-child[style="height: 16px;"] {
+  .container__7e23c
+    > .scroller__1f498
+    > .content__690c5
+    > div:first-child[style="height: 16px;"] {
     display: none;
   }
 

--- a/stuff/_friends.scss
+++ b/stuff/_friends.scss
@@ -156,7 +156,8 @@
 
     // Speaking ring
     .border_e782de.speaking_b20122 {
-      box-shadow: inset 0 0 0 2.5px #43b581,
+      box-shadow:
+        inset 0 0 0 2.5px #43b581,
         inset 0 0 0 6px var(--background-secondary);
     }
 
@@ -187,9 +188,8 @@
 
   // User profile
   .userPanelOuter_eb00b1 {
-
     .scrollerBase_f742b2 {
-      overflow: unset !important
+      overflow: unset !important;
     }
 
     // Banner

--- a/stuff/_member-list.scss
+++ b/stuff/_member-list.scss
@@ -236,7 +236,8 @@
     width: 800px;
     height: 100%;
 
-    & > div, .userProfileModalOuter_a65559 {
+    & > div,
+    .userProfileModalOuter_a65559 {
       width: 100%;
       height: 100%;
       box-sizing: border-box;

--- a/stuff/_user-area.scss
+++ b/stuff/_user-area.scss
@@ -75,7 +75,8 @@
 
       // Speaking ring
       .border_d9a17b.speaking_c28527 {
-        box-shadow: inset 0 0 0 2.5px #43b581,
+        box-shadow:
+          inset 0 0 0 2.5px #43b581,
           inset 0 0 0 4.5px var(--background-secondary);
       }
 


### PR DESCRIPTION
QOL stuff to make releasing for Replugged more streamlined, plus some fixes:

- add `pnpm run release` for automatically doing the version bump, tagging, and releasing.
- fix author format in manifest, with you as current maintainer at start of the list
- fix license to include your details
- fix and run linter: `pnpm lint`, `pnpm lint:fix`

Other considerations before future Replugged version updates:
- update `A user#8169`'s author info to their current username and discord id

Then all you need to do to update on Replugged store is `pnpm run release` and make a post in #addon-reviews.